### PR TITLE
Fixes #37

### DIFF
--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -116,9 +116,6 @@ void KMedoids::setLossFn(std::string loss) {
   } else if (std::isdigit(loss.at(0))) {
       lossFn = &KMedoids::LP;
       lp     = atoi(loss.c_str());
-      //std::stringstream st(loss);
-      //st >> lp;
-      //lp     = std::stoi(loss);
   } else {
       throw "unrecognized loss function";
   }

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -9,6 +9,7 @@
 
 #include <armadillo>
 #include <unordered_map>
+#include <regex>
 //#include <sstream>
 
 /**
@@ -107,6 +108,9 @@ int KMedoids::getSteps() {
  *  @param loss Loss function to be used e.g. L2
  */
 void KMedoids::setLossFn(std::string loss) {
+  if (std::regex_match(loss, std::regex("L\\d*"))) {
+      loss = loss.substr(1);
+  }
   try {
     if (loss == "manhattan") {
         lossFn = &KMedoids::manhattan;

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -107,9 +107,6 @@ int KMedoids::getSteps() {
  *  @param loss Loss function to be used e.g. L2
  */
 void KMedoids::setLossFn(std::string loss) {
-  if (loss.at(0) == 'L') {
-      loss = loss.substr(1);
-  }
   if (loss == "manhattan") {
       lossFn = &KMedoids::manhattan;
   } else if (loss == "cos") {

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -107,18 +107,22 @@ int KMedoids::getSteps() {
  *  @param loss Loss function to be used e.g. L2
  */
 void KMedoids::setLossFn(std::string loss) {
-  if (loss == "manhattan") {
-      lossFn = &KMedoids::manhattan;
-  } else if (loss == "cos") {
-      lossFn = &KMedoids::cos;
-  } else if (loss == "inf") {
-      lossFn = &KMedoids::LINF;
-  } else if (std::isdigit(loss.at(0))) {
-      lossFn = &KMedoids::LP;
-      lp     = atoi(loss.c_str());
-  } else {
-      throw "unrecognized loss function";
-  }
+  try {
+    if (loss == "manhattan") {
+        lossFn = &KMedoids::manhattan;
+    } else if (loss == "cos") {
+        lossFn = &KMedoids::cos;
+    } else if (loss == "inf") {
+        lossFn = &KMedoids::LINF;
+    } else if (std::isdigit(loss.at(0))) {
+        lossFn = &KMedoids::LP;
+        lp     = atoi(loss.c_str());
+    } else {
+        throw std::invalid_argument("error: unrecognized loss function");
+    }
+  } catch (std::invalid_argument& e) {
+      std::cout << e.what() << std::endl;
+    }
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <unistd.h>
 #include <exception>
+#include <regex>
 
 int main(int argc, char* argv[])
 {   
@@ -56,7 +57,7 @@ int main(int argc, char* argv[])
             // type of loss/distance function to use
             case 'l':
                 loss = optarg;
-                if (loss.at(0) == 'L') {
+                if (std::regex_match(loss, std::regex("L\\d*"))) {
                   loss = loss.substr(1);
                 }
                 break;


### PR DESCRIPTION
Fix bug in loss parsing by checking the format of the input loss string. When user enters loss in the form of `"L\d*"`, the whole numeric portion will be read into the variable `loss` and is treated as the `p` value in Lp norm. Loss function with the name starting with `L` but not in the form of `"L\d*"` will remain intact (but further implementation needs to be done in `kmedoids_ucb.cpp`).

For example:
1. `./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1 -l L15` will give `Medoids: 194,319,558,60,133,896,448,475,251,354`. 
2. `./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1  ` will give the expected result `Medoids: 694,800,306,714,324,959,737,527,168,251`.

