### PR TITLE
Rename 'final_medoids' Attribute of KMedoids to 'medoids'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ kmed.fit(X, 'L2', 3, "gmm_log")
 
 # Visualize the data and the medoids:
 for p_idx, point in enumerate(X):
-    if p_idx in map(int, kmed.final_medoids):
+    if p_idx in map(int, kmed.medoids):
         plt.scatter(X[p_idx, 0], X[p_idx, 1], color='red', s = 40)
     else:
         plt.scatter(X[p_idx, 0], X[p_idx, 1], color='blue', s = 10)
@@ -92,7 +92,7 @@ kmed.fit(X, 'L2', 10, "mnist_log")
 
 # Visualize the data and the medoids via t-SNE:
 for p_idx, point in enumerate(X):
-    if p_idx in map(int, kmed.final_medoids):
+    if p_idx in map(int, kmed.medoids):
         plt.scatter(X_tsne[p_idx, 0], X_tsne[p_idx, 1], color='red', s = 40)
     else:
         plt.scatter(X_tsne[p_idx, 0], X_tsne[p_idx, 1], color='blue', s = 5)

--- a/src/kmeds_pywrapper.cpp
+++ b/src/kmeds_pywrapper.cpp
@@ -100,7 +100,7 @@ PYBIND11_MODULE(BanditPAM, m) {
       .def_property("verbosity", &KMedsWrapper::getVerbosity, &KMedsWrapper::setVerbosity)
       .def_property("maxIter", &KMedsWrapper::getMaxIter, &KMedsWrapper::setMaxIter)
       .def_property("logFilename", &KMedsWrapper::getLogfileName, &KMedsWrapper::setLogFilename)
-      .def_property_readonly("final_medoids", &KMedsWrapper::getMedoidsFinalPython)
+      .def_property_readonly("medoids", &KMedsWrapper::getMedoidsFinalPython)
       .def_property_readonly("build_medoids", &KMedsWrapper::getMedoidsBuildPython)
       .def_property_readonly("labels", &KMedsWrapper::getLabelsPython)
       .def_property_readonly("steps", &KMedsWrapper::getStepsPython)

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -15,7 +15,7 @@ def onFly(k, data, loss):
     kmed_bpam.fit(data, loss)
     kmed_naive.fit(data, loss)
 
-    if (kmed_bpam.final_medoids.tolist() == kmed_naive.final_medoids.tolist()) and \
+    if (kmed_bpam.medoids.tolist() == kmed_naive.medoids.tolist()) and \
        (kmed_bpam.build_medoids.tolist() == kmed_naive.build_medoids.tolist()):
         return 1
     else:
@@ -64,7 +64,7 @@ class PythonTests(unittest.TestCase):
         kmed_5.fit(self.small_mnist, "L2")
 
         self.assertEqual(kmed_5.build_medoids.tolist(), np.array([16, 32, 70, 87, 24]).tolist())
-        self.assertEqual(kmed_5.final_medoids.tolist(), np.array([30, 99, 70, 23, 49]).tolist())
+        self.assertEqual(kmed_5.medoids.tolist(), np.array([30, 99, 70, 23, 49]).tolist())
 
         kmed_10 = KMedoids(
             n_medoids = 10,
@@ -76,7 +76,7 @@ class PythonTests(unittest.TestCase):
         kmed_10.fit(self.small_mnist, "L2")
 
         self.assertEqual(kmed_10.build_medoids.tolist(), np.array([16, 32, 70, 87, 24, 90, 49, 99, 82, 94]).tolist())
-        self.assertEqual(kmed_10.final_medoids.tolist(), np.array([16, 63, 70, 25, 31, 90, 49, 99, 82, 94]).tolist())
+        self.assertEqual(kmed_10.medoids.tolist(), np.array([16, 63, 70, 25, 31, 90, 49, 99, 82, 94]).tolist())
 
     def test_small_cases_scrna(self):
         '''
@@ -92,7 +92,7 @@ class PythonTests(unittest.TestCase):
         kmed_5.fit(self.scrna.head(1000).to_numpy(), "L1")
 
         self.assertEqual(kmed_5.build_medoids.tolist(), np.array([377, 267, 276, 762, 394]).tolist())
-        self.assertEqual(kmed_5.final_medoids.tolist(), np.array([377, 267, 276, 762, 394]).tolist())
+        self.assertEqual(kmed_5.medoids.tolist(), np.array([377, 267, 276, 762, 394]).tolist())
 
         kmed_10 = KMedoids(
             n_medoids = 10,
@@ -104,7 +104,7 @@ class PythonTests(unittest.TestCase):
         kmed_10.fit(self.scrna.head(1000).to_numpy(), "L1")
 
         self.assertEqual(kmed_10.build_medoids.tolist(), np.array([377, 267, 276, 762, 394, 311, 663, 802, 422, 20]).tolist())
-        self.assertEqual(kmed_10.final_medoids.tolist(), np.array([377, 267, 276, 762, 394, 311, 663, 802, 422, 20]).tolist())
+        self.assertEqual(kmed_10.medoids.tolist(), np.array([377, 267, 276, 762, 394, 311, 663, 802, 422, 20]).tolist())
 
     def test_edge_cases(self):
         '''
@@ -113,7 +113,7 @@ class PythonTests(unittest.TestCase):
         kmed = KMedoids()
 
         # initialized to empty
-        self.assertEqual([], kmed.final_medoids.tolist())
+        self.assertEqual([], kmed.medoids.tolist())
         self.assertEqual([], kmed.build_medoids.tolist())
 
         # error on trying to fit on empty

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -15,7 +15,7 @@ def onFly(k, data, loss):
     kmed_bpam.fit(data, loss)
     kmed_naive.fit(data, loss)
 
-    if (kmed_bpam.final_medoids.tolist() == kmed_naive.final_medoids.tolist()) and \
+    if (kmed_bpam.medoids.tolist() == kmed_naive.medoids.tolist()) and \
        (kmed_bpam.build_medoids.tolist() == kmed_naive.build_medoids.tolist()):
         return 1
     else:


### PR DESCRIPTION
As per the description in Issue #38, the term `final_medoids` can confusing and counterintuitive. Since it's unlikely anyone will use `build_medoids`, we have decided to rename `final_medoids` to `medoids`. This task has been accomplished by modifying the Python wrapper as well as the corresponding test files. The README has also been updated to reflect the change in the name of the `KMedoids` attribute to `medoids`. The command `./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1 ` was run to ensure that the renaming process did not alter the program functionality, and indeed the proper set of medoids (`Medoids: 694,800,306,714,324,959,737,527,168,251`) were outputted.