### PR TITLE
Add argument n for logfile name. Fixes #54

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
     bool k_flag = false;
     const int ARGUMENT_ERROR_CODE = 1;
 
-    while (prev_ind = optind, (opt = getopt(argc, argv, "f:l:k:v:")) != -1) {
+    while (prev_ind = optind, (opt = getopt(argc, argv, "f:l:k:v:n:")) != -1) {
 
         if ( optind == prev_ind + 2 && *optarg == '-' ) {
         opt = ':';

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
     bool k_flag = false;
     const int ARGUMENT_ERROR_CODE = 1;
 
-    while (prev_ind = optind, (opt = getopt(argc, argv, "f:l:k:v:n:")) != -1) {
+    while (prev_ind = optind, (opt = getopt(argc, argv, "f:l:k:v:s:")) != -1) {
 
         if ( optind == prev_ind + 2 && *optarg == '-' ) {
         opt = ':';
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
                 f_flag = true;
                 break;
             // path to log output data
-            case 'n':
+            case 's':
                 log_file_name = optarg;
                 break;
             // number of clusters to create


### PR DESCRIPTION
Added back the missing argument `n` to the `getopt` function. The following is an example of renaming the log file in the output:
```
./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1 -n BanditPAM_log_file
```
We get the expected results with log file named `BanditPAM_log_file` as output:
```
Medoids: 694,800,306,714,324,959,737,527,168,251
```
