### PR TITLE
Remove global variables. Fixes #31

### DIFF
--- a/headers/kmedoids_ucb.hpp
+++ b/headers/kmedoids_ucb.hpp
@@ -173,16 +173,18 @@ class KMedoids {
 
     void fit_naive(arma::mat inputData);
 
-    void build_naive(arma::rowvec& medoidIndices);
+    void build_naive(arma::mat& data, arma::rowvec& medoidIndices);
 
-    void swap_naive(arma::rowvec& medoidIndices);
+    void swap_naive(arma::mat& data, arma::rowvec& medoidIndices);
 
     void build(
+      arma::mat& data,
       arma::rowvec& medoidIndices,
       arma::mat& medoids
     );
 
     void build_sigma(
+      arma::mat& data,
       arma::rowvec& best_distances,
       arma::rowvec& sigma,
       arma::uword batch_size,
@@ -190,6 +192,7 @@ class KMedoids {
     );
 
     arma::rowvec build_target(
+      arma::mat& data,
       arma::uvec& target,
       size_t batch_size,
       arma::rowvec& best_distances,
@@ -197,12 +200,14 @@ class KMedoids {
     );
 
     void swap(
+      arma::mat& data,
       arma::rowvec& medoidIndices,
       arma::mat& medoids,
       arma::rowvec& assignments
     );
 
     void calc_best_distances_swap(
+      arma::mat& data,
       arma::rowvec& medoidIndices,
       arma::rowvec& best_distances,
       arma::rowvec& second_distances,
@@ -210,6 +215,7 @@ class KMedoids {
     );
 
     arma::vec swap_target(
+      arma::mat& data,
       arma::rowvec& medoidIndices,
       arma::uvec& targets,
       size_t batch_size,
@@ -219,6 +225,7 @@ class KMedoids {
     );
 
     void swap_sigma(
+      arma::mat& data,
       arma::mat& sigma,
       size_t batch_size,
       arma::rowvec& best_distances,
@@ -226,17 +233,17 @@ class KMedoids {
       arma::rowvec& assignments
     );
 
-    double calc_loss(arma::rowvec& medoidIndices);
+    double calc_loss(arma::mat& data, arma::rowvec& medoidIndices);
 
     // Loss functions
     int lp;
-    double LP(int i, int j) const;
+    double LP(arma::mat& data, int i, int j) const;
 
-    double LINF(int i, int j) const;
+    double LINF(arma::mat& data, int i, int j) const;
 
-    double cos(int i, int j) const;
+    double cos(arma::mat& data, int i, int j) const;
 
-    double manhattan(int i, int j) const;
+    double manhattan(arma::mat& data, int i, int j) const;
 
     void checkAlgorithm(std::string algorithm);
 
@@ -260,7 +267,7 @@ class KMedoids {
 
     arma::rowvec medoid_indices_final; ///< medoids at the end of the swap step
 
-    double (KMedoids::*lossFn)(int i, int j) const; ///< loss function used during KMedoids::fit
+    double (KMedoids::*lossFn)(arma::mat& data, int i, int j) const; ///< loss function used during KMedoids::fit
 
     void (KMedoids::*fitFn)(arma::mat inputData); ///< function used for finding medoids (from algorithm)
 


### PR DESCRIPTION
The original code assigns the transposed input data to a variable called `data` in `fit_naive()` and `fit_bpam()` and uses it as a global variable for all called functions like `build_naive(), swap_naive(), build(), swap()`. The dependence of the functions is as follows 
 
```
1. KMedoids::fit_naive() 
    |- KMedoids::build_naive()
               |- KMedoids::lossFn()
    |- KMedoids::swap_naive()
               |- KMedoids::lossFn()

2. KMedoids::fit_bpam()
    |- KMedoids::build()
         |- KMedoids::build_sigma()
                    |- KMedoids::lossFn()
         |- KMedoids::build_target()
                    |- KMedoids::lossFn()
    |- KMedoids::swap()
         |- KMedoids::calc_best_distances_swap()
                    |- KMedoids::lossFn()
         |- KMedoids::swap_sigma()
                    |- KMedoids::lossFn()
         |- KMedoids::swap_target() 
                    |- KMedoids::lossFn()

3. KMedoids::calc_loss()
    |- KMedoids::lossFn()
```

where the `lossFn()` needs the information from `data` to compute the loss. Pass by reference is used to pass the `data` from one level to the other level of the hierarchy of functions. We added the argument `arma::mat& data` as input for the affected functions and their corresponding constructors in the header file. 

We tested the updated code with the standard case `./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1` and other cases with loss function changed to `manhattan, cos, inf, L15`. All of them give the expected set of medoids. 
