### PR TITLE
remove redundant medoids number k in Python fit method. Fixes #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ means = np.array([[0,0], [-5,5], [5,5]])
 X = np.vstack([np.random.randn(n_per_cluster, 2) + mu for mu in means])
 
 # Fit the data with BanditPAM:
-kmed = KMedoids(n_medoids = 3, algorithm = "BanditPAM")
+k = 3
+kmed = KMedoids(n_medoids = k, algorithm = "BanditPAM")
 # Writes results to gmm_log
-kmed.fit(X, 'L2', 3, "gmm_log")
+kmed.fit(X, 'L2', k, "gmm_log")
 
 # Visualize the data and the medoids:
 for p_idx, point in enumerate(X):
@@ -87,8 +88,9 @@ X = pd.read_csv('data/MNIST-1k.csv', sep=' ', header=None).to_numpy()
 X_tsne = TSNE(n_components = 2).fit_transform(X)
 
 # Fit the data with BanditPAM:
-kmed = KMedoids(n_medoids = 10, algorithm = "BanditPAM")
-kmed.fit(X, 'L2', 10, "mnist_log")
+k = 10
+kmed = KMedoids(n_medoids = k, algorithm = "BanditPAM")
+kmed.fit(X, 'L2', k, "mnist_log")
 
 # Visualize the data and the medoids via t-SNE:
 for p_idx, point in enumerate(X):

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ X = np.vstack([np.random.randn(n_per_cluster, 2) + mu for mu in means])
 k = 3
 kmed = KMedoids(n_medoids = k, algorithm = "BanditPAM")
 # Writes results to gmm_log
-kmed.fit(X, 'L2', k, "gmm_log")
+kmed.fit(X, 'L2', "gmm_log")
 
 # Visualize the data and the medoids:
 for p_idx, point in enumerate(X):
@@ -90,7 +90,7 @@ X_tsne = TSNE(n_components = 2).fit_transform(X)
 # Fit the data with BanditPAM:
 k = 10
 kmed = KMedoids(n_medoids = k, algorithm = "BanditPAM")
-kmed.fit(X, 'L2', k, "mnist_log")
+kmed.fit(X, 'L2', "mnist_log")
 
 # Visualize the data and the medoids via t-SNE:
 for p_idx, point in enumerate(X):

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ means = np.array([[0,0], [-5,5], [5,5]])
 X = np.vstack([np.random.randn(n_per_cluster, 2) + mu for mu in means])
 
 # Fit the data with BanditPAM:
-k = 3
-kmed = KMedoids(n_medoids = k, algorithm = "BanditPAM")
+kmed = KMedoids(n_medoids = 3, algorithm = "BanditPAM")
 # Writes results to gmm_log
 kmed.fit(X, 'L2', "gmm_log")
 
@@ -88,8 +87,7 @@ X = pd.read_csv('data/MNIST-1k.csv', sep=' ', header=None).to_numpy()
 X_tsne = TSNE(n_components = 2).fit_transform(X)
 
 # Fit the data with BanditPAM:
-k = 10
-kmed = KMedoids(n_medoids = k, algorithm = "BanditPAM")
+kmed = KMedoids(n_medoids = 10, algorithm = "BanditPAM")
 kmed.fit(X, 'L2', "mnist_log")
 
 # Visualize the data and the medoids via t-SNE:

--- a/headers/kmedoids_ucb.hpp
+++ b/headers/kmedoids_ucb.hpp
@@ -129,8 +129,7 @@ struct LogHelper {
 class KMedoids {
   public:
     KMedoids(int n_medoids = 5, std::string algorithm = "BanditPAM", int verbosity = 0, int max_iter = 1000, std::string logFilename = "KMedoidsLogfile");
-    KMedoids(std::string algorithm = "BanditPAM", int verbosity = 0, int max_iter = 1000, std::string logFilename = "KMedoidsLogfile");
-
+    
     ~KMedoids();
 
     void fit(arma::mat inputData, std::string loss);

--- a/headers/kmedoids_ucb.hpp
+++ b/headers/kmedoids_ucb.hpp
@@ -129,6 +129,7 @@ struct LogHelper {
 class KMedoids {
   public:
     KMedoids(int n_medoids = 5, std::string algorithm = "BanditPAM", int verbosity = 0, int max_iter = 1000, std::string logFilename = "KMedoidsLogfile");
+    KMedoids(std::string algorithm = "BanditPAM", int verbosity = 0, int max_iter = 1000, std::string logFilename = "KMedoidsLogfile");
 
     ~KMedoids();
 

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -36,6 +36,15 @@ KMedoids::KMedoids(int n_medoids, std::string algorithm, int verbosity,
   KMedoids::checkAlgorithm(algorithm);
 }
 
+KMedoids::KMedoids(std::string algorithm, int verbosity,
+                                          int max_iter, std::string logFilename
+    ): algorithm(algorithm),
+       max_iter(max_iter),
+       verbosity(verbosity),
+       logFilename(logFilename) {
+  KMedoids::checkAlgorithm(algorithm);
+}
+
 /**
  *  \brief Destroys KMedoids object.
  *

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -36,15 +36,6 @@ KMedoids::KMedoids(int n_medoids, std::string algorithm, int verbosity,
   KMedoids::checkAlgorithm(algorithm);
 }
 
-KMedoids::KMedoids(std::string algorithm, int verbosity,
-                                          int max_iter, std::string logFilename
-    ): algorithm(algorithm),
-       max_iter(max_iter),
-       verbosity(verbosity),
-       logFilename(logFilename) {
-  KMedoids::checkAlgorithm(algorithm);
-}
-
 /**
  *  \brief Destroys KMedoids object.
  *

--- a/src/kmeds_pywrapper.cpp
+++ b/src/kmeds_pywrapper.cpp
@@ -35,9 +35,11 @@ public:
    *
    * @param inputData Input data to find the medoids of
    * @param loss The loss function used during medoid computation
+   * @param k The number of medoids to compute
    * @param logFilename The name of the outputted log file
    */
-  void fitPython(py::array_t<double> inputData, std::string loss, std::string logFilename) {
+  void fitPython(py::array_t<double> inputData, std::string loss, int k, std::string logFilename) {
+    KMedoids::setNMedoids(k);
     KMedoids::setLogFilename(logFilename);
     KMedoids::fit(carma::arr_to_mat<double>(inputData), loss);
   }

--- a/src/kmeds_pywrapper.cpp
+++ b/src/kmeds_pywrapper.cpp
@@ -35,11 +35,9 @@ public:
    *
    * @param inputData Input data to find the medoids of
    * @param loss The loss function used during medoid computation
-   * @param k The number of medoids to compute
    * @param logFilename The name of the outputted log file
    */
-  void fitPython(py::array_t<double> inputData, std::string loss, int k, std::string logFilename) {
-    KMedoids::setNMedoids(k);
+  void fitPython(py::array_t<double> inputData, std::string loss, std::string logFilename) {
     KMedoids::setLogFilename(logFilename);
     KMedoids::fit(carma::arr_to_mat<double>(inputData), loss);
   }

--- a/src/kmeds_pywrapper.cpp
+++ b/src/kmeds_pywrapper.cpp
@@ -41,16 +41,13 @@ public:
   void fitPython(py::array_t<double> inputData, std::string loss, std::string logFilename, py::kwargs kw) {
     // throw an error if the number of medoids is not specified in either the KMedoids object or the fitPython function
     try {
-      if (!KMedoids::getNMedoids()) {
+      if (KMedoids::getNMedoids() == NULL) {
         if (kw.size() == 0) {
-          throw py::value_error("n_medoids");
+          throw py::value_error("Must specify number of medoids via n_medoids in KMedoids or k in fit function.");
         }
       }
-    } catch (py::error_already_set &c) {
-       // py::value_error is not a Python exception
-      assert(false);
     } catch (py::value_error &e) {
-      py::print("error: Must specify number of medoids via n_medoids in KMedoids or k in fit function.");
+      // Throw it again (pybind11 will raise ValueError)
       throw;
     }
     // if k is specified here, we set the number of medoids as k and override previous value 
@@ -106,13 +103,7 @@ PYBIND11_MODULE(BanditPAM, m) {
   m.doc() = "BanditPAM Python library, implemented in C++";
   py::class_<KMedsWrapper>(m, "KMedoids")
       .def(py::init<int, std::string, int, int, std::string>(),
-        py::arg("n_medoids"),
-        py::arg("algorithm") = "BanditPAM",
-        py::arg("verbosity") = 0,
-        py::arg("maxIter") = 1000,
-        py::arg("logFilename") = "KMedoidsLogfile"
-      )
-      .def(py::init<std::string, int, int, std::string>(),
+        py::arg("n_medoids") = NULL,
         py::arg("algorithm") = "BanditPAM",
         py::arg("verbosity") = 0,
         py::arg("maxIter") = 1000,

--- a/src/kmeds_pywrapper.cpp
+++ b/src/kmeds_pywrapper.cpp
@@ -39,7 +39,8 @@ public:
    * @param logFilename The name of the outputted log file
    */
   void fitPython(py::array_t<double> inputData, std::string loss, std::string logFilename, py::kwargs kw) {
-    // throw an error if the number of medoids is not specified in either the KMedoids object or the fitPython function
+    // throw an error if the number of medoids is not specified in either 
+    // the KMedoids object or the fitPython function
     try {
       if (KMedoids::getNMedoids() == NULL) {
         if (kw.size() == 0) {

--- a/src/kmeds_pywrapper.cpp
+++ b/src/kmeds_pywrapper.cpp
@@ -38,8 +38,25 @@ public:
    * @param k The number of medoids to compute
    * @param logFilename The name of the outputted log file
    */
-  void fitPython(py::array_t<double> inputData, std::string loss, int k, std::string logFilename) {
-    KMedoids::setNMedoids(k);
+  void fitPython(py::array_t<double> inputData, std::string loss, std::string logFilename, py::kwargs kw) {
+    // throw an error if the number of medoids is not specified in either the KMedoids object or the fitPython function
+    try {
+      if (!KMedoids::getNMedoids()) {
+        if (kw.size() == 0) {
+          throw py::value_error("n_medoids");
+        }
+      }
+    } catch (py::error_already_set &c) {
+       // py::value_error is not a Python exception
+      assert(false);
+    } catch (py::value_error &e) {
+      py::print("error: Must specify number of medoids via n_medoids in KMedoids or k in fit function.");
+      throw;
+    }
+    // if k is specified here, we set the number of medoids as k and override previous value 
+    if ((kw.size() != 0) && (kw["k"])) {
+      KMedoids::setNMedoids(py::cast<int>(kw["k"]));
+    }
     KMedoids::setLogFilename(logFilename);
     KMedoids::fit(carma::arr_to_mat<double>(inputData), loss);
   }
@@ -89,7 +106,13 @@ PYBIND11_MODULE(BanditPAM, m) {
   m.doc() = "BanditPAM Python library, implemented in C++";
   py::class_<KMedsWrapper>(m, "KMedoids")
       .def(py::init<int, std::string, int, int, std::string>(),
-        py::arg("n_medoids") = 5,
+        py::arg("n_medoids"),
+        py::arg("algorithm") = "BanditPAM",
+        py::arg("verbosity") = 0,
+        py::arg("maxIter") = 1000,
+        py::arg("logFilename") = "KMedoidsLogfile"
+      )
+      .def(py::init<std::string, int, int, std::string>(),
         py::arg("algorithm") = "BanditPAM",
         py::arg("verbosity") = 0,
         py::arg("maxIter") = 1000,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
                 input_name = optarg;
                 f_flag = true;
                 break;
-            // path to log output data
+            // name of the output log file
             case 's':
                 log_file_name = optarg;
                 break;


### PR DESCRIPTION
The argument `k` in Python fit method is redundant since we have already specified the medoids number when we instantiate the `KMedoids` class. We therefore remove this argument in `fitPython()` method in `KMedsWrapper` class. The Python examples in repo are tested again using the updated code and the results are as follow:

<img width="718" alt="BanditPAM_GMM_new_code" src="https://user-images.githubusercontent.com/25496074/121255946-062b5300-c87a-11eb-9e92-650a7d157c4d.png">

<img width="864" alt="BanditPAM_MNIST_new_code" src="https://user-images.githubusercontent.com/25496074/121256254-599da100-c87a-11eb-8aad-a5355a3b1184.png">

The standard cases `./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1` with different loss functions `manhattan, cos, inf, L15` are also tested and they all give the expected results. 