### PR TITLE
add version attribute to python module. Fixes #63

### DIFF
--- a/src/kmeds_pywrapper.cpp
+++ b/src/kmeds_pywrapper.cpp
@@ -124,8 +124,8 @@ PYBIND11_MODULE(BanditPAM, m) {
       .def_property_readonly("steps", &KMedsWrapper::getStepsPython)
       .def("fit", &KMedsWrapper::fitPython);
 #ifdef VERSION_INFO
-    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
+  m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
 #else
-    m.attr("__version__") = "dev";
+  m.attr("__version__") = "dev";
 #endif
 }

--- a/src/kmeds_pywrapper.cpp
+++ b/src/kmeds_pywrapper.cpp
@@ -14,6 +14,9 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
+#define STRINGIFY(x) #x
+#define MACRO_STRINGIFY(x) STRINGIFY(x)
+
 
 namespace py = pybind11;
 
@@ -120,4 +123,9 @@ PYBIND11_MODULE(BanditPAM, m) {
       .def_property_readonly("labels", &KMedsWrapper::getLabelsPython)
       .def_property_readonly("steps", &KMedsWrapper::getStepsPython)
       .def("fit", &KMedsWrapper::fitPython);
+#ifdef VERSION_INFO
+    m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
+#else
+    m.attr("__version__") = "dev";
+#endif
 }


### PR DESCRIPTION
Add version attribute in pybind module `PYBIND11_MODULE(BanditPAM, m)` for the version of python package. The version number follows the value of `__version__` in `setup.py` file. 

The current version of this package is 
<img width="346" alt="Screen Shot 2021-07-04 at 11 18 01 PM" src="https://user-images.githubusercontent.com/25496074/124413159-166e0b00-dd1e-11eb-89bf-20e1b0e57803.png">

The update follows an example for version attribute from pybind doc: https://github.com/pybind/python_example/blob/master/src/main.cpp

The following 2 lines are used to covert a macro argument `VERSION_INFO` to a string constant:
```
#define STRINGIFY(x) #x
#define MACRO_STRINGIFY(x) STRINGIFY(x)
```
and here is the reference: https://gcc.gnu.org/onlinedocs/cpp/Stringizing.html#Stringizing

