### PR TITLE
complete the logfile for naive algorithm. Fixes #53

### DIFF
--- a/headers/kmedoids_ucb.hpp
+++ b/headers/kmedoids_ucb.hpp
@@ -175,7 +175,7 @@ class KMedoids {
 
     void build_naive(arma::mat& data, arma::rowvec& medoidIndices);
 
-    void swap_naive(arma::mat& data, arma::rowvec& medoidIndices);
+    void swap_naive(arma::mat& data, arma::rowvec& medoidIndices, arma::rowvec& assignments);
 
     void build(
       arma::mat& data,

--- a/headers/kmedoids_ucb.hpp
+++ b/headers/kmedoids_ucb.hpp
@@ -233,6 +233,8 @@ class KMedoids {
       arma::rowvec& assignments
     );
 
+    void sigma_log(arma::mat& sigma);
+
     double calc_loss(arma::mat& data, arma::rowvec& medoidIndices);
 
     // Loss functions

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -269,16 +269,19 @@ void KMedoids::fit_naive(arma::mat input_data) {
   steps = 0;
 
   medoid_indices_build = medoid_indices;
+  arma::rowvec assignments(data.n_cols);
   size_t i = 0;
   bool medoidChange = true;
   while (i < max_iter && medoidChange) {
     auto previous(medoid_indices);
     // runs swa step as necessary
-    KMedoids::swap_naive(data, medoid_indices);
+    KMedoids::swap_naive(data, medoid_indices, assignments);
     medoidChange = arma::any(medoid_indices != previous);
     i++;
   }
   medoid_indices_final = medoid_indices;
+  labels = assignments;
+  steps = i;
 }
 
 /**
@@ -295,10 +298,19 @@ void KMedoids::fit_naive(arma::mat input_data) {
 void KMedoids::build_naive(
   arma::mat& data, 
   arma::rowvec& medoid_indices)
-{
+{ 
+  size_t N = data.n_cols;
+  int p = (buildConfidence * N); // reciprocal
+  bool use_absolute = true;
+  arma::rowvec estimates(N, arma::fill::zeros);
+  arma::rowvec best_distances(N);
+  best_distances.fill(std::numeric_limits<double>::infinity());
+  arma::rowvec sigma(N); // standard deviation of induced losses on reference points
   for (size_t k = 0; k < n_medoids; k++) {
     double minDistance = std::numeric_limits<double>::infinity();
     int best = 0;
+    KMedoids::build_sigma(
+           data, best_distances, sigma, batchSize, use_absolute); // computes std dev amongst batch of reference points
     // fixes a base datapoint
     for (int i = 0; i < data.n_cols; i++) {
       double total = 0;
@@ -321,6 +333,19 @@ void KMedoids::build_naive(
     }
     // updates the medoid index for that of lowest cost.
     medoid_indices(k) = best;
+
+    // don't need to do this on final iteration
+    for (size_t l = 0; l < N; l++) {
+        double cost = (this->*lossFn)(data, l, medoid_indices(k));
+        if (cost < best_distances(l)) {
+            best_distances(l) = cost;
+        }
+    }
+    use_absolute = false; // use difference of loss for sigma and sampling,
+                          // not absolute
+    logHelper.loss_build.push_back(minDistance/N);
+    logHelper.p_build.push_back((float)1/(float)p);
+    logHelper.comp_exact_build.push_back(N);
   }
 }
 
@@ -334,14 +359,45 @@ void KMedoids::build_naive(
  * @param data Transposed input data to find the medoids of
  * @param medoid_indices Array of medoid indices created from the build step
  * that is modified in place as better medoids are identified
+ * @param assignments Uninitialized array of indices corresponding to each
+ * datapoint assigned the index of the medoid it is closest to
  */
 void KMedoids::swap_naive(
   arma::mat& data, 
-  arma::rowvec& medoid_indices)
+  arma::rowvec& medoid_indices,
+  arma::rowvec& assignments)
 {
   double minDistance = std::numeric_limits<double>::infinity();
   size_t best = 0;
   size_t medoid_to_swap = 0;
+  size_t N = data.n_cols;
+  int p = (N * n_medoids * swapConfidence); // reciprocal
+  arma::mat sigma(n_medoids, N, arma::fill::zeros);
+  arma::rowvec best_distances(N);
+  arma::rowvec second_distances(N);
+
+  // calculate quantities needed for swap, best_distances and sigma
+  calc_best_distances_swap(
+    data, medoid_indices, best_distances, second_distances, assignments);
+
+  swap_sigma(data,
+              sigma,
+              batchSize,
+              best_distances,
+              second_distances,
+              assignments);
+  arma::rowvec flat_sigma = sigma.as_row(); 
+  arma::rowvec P = {0.25, 0.5, 0.75};
+  arma::rowvec Q = arma::quantile(flat_sigma, P);
+  std::ostringstream sigma_out;
+  sigma_out << "min: " << arma::min(flat_sigma)
+            << ", 25th: " << Q(0)
+            << ", median: " << Q(1)
+            << ", 75th: " << Q(2)
+            << ", max: " << arma::max(flat_sigma)
+            << ", mean: " << arma::mean(flat_sigma);
+  logHelper.sigma_swap.push_back(sigma_out.str());
+
   // iterate across the current medoids
   for (size_t k = 0; k < n_medoids; k++) {
     // for every point in our dataset, let it serve as a "base" point
@@ -371,6 +427,9 @@ void KMedoids::swap_naive(
     }
   }
   medoid_indices(medoid_to_swap) = best;
+  logHelper.loss_swap.push_back(minDistance/N);
+  logHelper.p_swap.push_back((float)1/(float)p);
+  logHelper.comp_exact_swap.push_back(N*n_medoids);
 }
 
 /**
@@ -725,10 +784,16 @@ void KMedoids::swap(
         medoids.col(k) = data.col(medoid_indices(k));
         calc_best_distances_swap(
           data, medoid_indices, best_distances, second_distances, assignments);
+        arma::rowvec flat_sigma = sigma.as_row(); 
+        arma::rowvec P = {0.25, 0.5, 0.75};
+        arma::rowvec Q = arma::quantile(flat_sigma, P);
         std::ostringstream sigma_out;
-        sigma_out << "Sigma: min: " << sigma.min()
-        << ", max: " << sigma.max()
-        << ", mean: " << arma::mean(arma::mean(sigma));
+        sigma_out << "min: " << arma::min(flat_sigma)
+                  << ", 25th: " << Q(0)
+                  << ", median: " << Q(1)
+                  << ", 75th: " << Q(2)
+                  << ", max: " << arma::max(flat_sigma)
+                  << ", mean: " << arma::mean(flat_sigma);
         logHelper.sigma_swap.push_back(sigma_out.str());
         logHelper.loss_swap.push_back(arma::mean(arma::mean(best_distances)));
         logHelper.p_swap.push_back((float)1/(float)p);

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -386,17 +386,9 @@ void KMedoids::swap_naive(
               best_distances,
               second_distances,
               assignments);
-  arma::rowvec flat_sigma = sigma.as_row(); 
-  arma::rowvec P = {0.25, 0.5, 0.75};
-  arma::rowvec Q = arma::quantile(flat_sigma, P);
-  std::ostringstream sigma_out;
-  sigma_out << "min: " << arma::min(flat_sigma)
-            << ", 25th: " << Q(0)
-            << ", median: " << Q(1)
-            << ", 75th: " << Q(2)
-            << ", max: " << arma::max(flat_sigma)
-            << ", mean: " << arma::mean(flat_sigma);
-  logHelper.sigma_swap.push_back(sigma_out.str());
+  
+  // write the sigma distribution to logfile
+  sigma_log(sigma);
 
   // iterate across the current medoids
   for (size_t k = 0; k < n_medoids; k++) {
@@ -784,17 +776,7 @@ void KMedoids::swap(
         medoids.col(k) = data.col(medoid_indices(k));
         calc_best_distances_swap(
           data, medoid_indices, best_distances, second_distances, assignments);
-        arma::rowvec flat_sigma = sigma.as_row(); 
-        arma::rowvec P = {0.25, 0.5, 0.75};
-        arma::rowvec Q = arma::quantile(flat_sigma, P);
-        std::ostringstream sigma_out;
-        sigma_out << "min: " << arma::min(flat_sigma)
-                  << ", 25th: " << Q(0)
-                  << ", median: " << Q(1)
-                  << ", 75th: " << Q(2)
-                  << ", max: " << arma::max(flat_sigma)
-                  << ", mean: " << arma::mean(flat_sigma);
-        logHelper.sigma_swap.push_back(sigma_out.str());
+        sigma_log(sigma);
         logHelper.loss_swap.push_back(arma::mean(arma::mean(best_distances)));
         logHelper.p_swap.push_back((float)1/(float)p);
     }
@@ -961,6 +943,28 @@ void KMedoids::swap_sigma(
         sigma(k, n) = arma::stddev(sample);
     }
 }
+
+/**
+* \brief Write the sigma distribution into logfile
+*
+* Calculates the statistical measures of the sigma distribution
+* and writes the results to the log file. 
+*
+* @param sigma Dispersion paramater for each datapoint
+*/
+void KMedoids::sigma_log(arma::mat& sigma) {
+  arma::rowvec flat_sigma = sigma.as_row(); 
+  arma::rowvec P = {0.25, 0.5, 0.75};
+  arma::rowvec Q = arma::quantile(flat_sigma, P);
+  std::ostringstream sigma_out;
+  sigma_out << "min: " << arma::min(flat_sigma)
+            << ", 25th: " << Q(0)
+            << ", median: " << Q(1)
+            << ", 75th: " << Q(2)
+            << ", max: " << arma::max(flat_sigma)
+            << ", mean: " << arma::mean(flat_sigma);
+  logHelper.sigma_swap.push_back(sigma_out.str());
+};
 
 /**
  * \brief Calculate loss for medoids


### PR DESCRIPTION
I have filled in all the fields of the log file for the `naive` algorithm and tested it using the same example in issue #53  

<img width="1096" alt="Screen Shot 2021-07-11 at 12 05 03 PM" src="https://user-images.githubusercontent.com/25496074/125202172-68dc8980-e240-11eb-9f32-6141f1a445c7.png">

The corresponding log file is
```
Built:891,392,354,714,23,805,527,777,251,972
Swapped:694,168,306,714,324,959,527,800,251,737
Num Swaps: 10
Final Loss: 7.44375
Build Logstring:
		:compute_exactly
				0: 1000
				1: 1000
				2: 1000
				3: 1000
				4: 1000
				5: 1000
				6: 1000
				7: 1000
				8: 1000
				9: 1000
		:loss
				0: 8.97142
				1: 8.64027
				2: 8.40195
				3: 8.21948
				4: 8.05052
				5: 7.91262
				6: 7.80759
				7: 7.7083
				8: 7.6153
				9: 7.54378
		:p
				0: 1e-06
				1: 1e-06
				2: 1e-06
				3: 1e-06
				4: 1e-06
				5: 1e-06
				6: 1e-06
				7: 1e-06
				8: 1e-06
				9: 1e-06
		:sigma
				0: min: 0.489725, 25th: 1.01001, median: 1.16105, 75th: 1.37448, max: 2.18534, mean: 1.21614
				1: min: 0, 25th: 0.349766, median: 0.474787, 75th: 0.625075, max: 1.74228, mean: 0.524651
				2: min: 0, 25th: 0.202488, median: 0.324991, 75th: 0.470902, max: 1.16009, mean: 0.37049
				3: min: 0, 25th: 0.196805, median: 0.290921, 75th: 0.420288, max: 1.27613, mean: 0.34678
				4: min: 0, 25th: 0.128208, median: 0.224885, 75th: 0.357447, max: 1.16287, mean: 0.284514
				5: min: 0, 25th: 0.123521, median: 0.207832, 75th: 0.329014, max: 1.16064, mean: 0.274838
				6: min: 0, 25th: 0.103736, median: 0.172772, 75th: 0.266333, max: 1.16938, mean: 0.235552
				7: min: 0, 25th: 0.103442, median: 0.174729, 75th: 0.264092, max: 1.16938, mean: 0.235798
				8: min: 0, 25th: 0.0915343, median: 0.163684, 75th: 0.266476, max: 1.17429, mean: 0.23016
				9: min: 0, 25th: 0.0847548, median: 0.15045, 75th: 0.24202, max: 1.09766, mean: 0.210791
Swap Logstring:
		:compute_exactly
				0: 10000
				1: 10000
				2: 10000
				3: 10000
				4: 10000
				5: 10000
				6: 10000
				7: 10000
				8: 10000
				9: 10000
		:loss
				0: 7.52346
				1: 7.50876
				2: 7.49285
				3: 7.48046
				4: 7.47164
				5: 7.46393
				6: 7.45825
				7: 7.44646
				8: 7.44375
				9: 7.44375
		:p
				0: 1e-08
				1: 1e-08
				2: 1e-08
				3: 1e-08
				4: 1e-08
				5: 1e-08
				6: 1e-08
				7: 1e-08
				8: 1e-08
				9: 1e-08
		:sigma
				0: min: 0, 25th: 0.272032, median: 0.395535, 75th: 0.479103, max: 1.3969, mean: 0.445857
				1: min: 0, 25th: 0.383465, median: 0.460167, 75th: 0.795845, max: 1.56954, mean: 0.57425
				2: min: 0, 25th: 0.333785, median: 0.473002, 75th: 0.783788, max: 1.48711, mean: 0.540798
				3: min: 0, 25th: 0.305567, median: 0.499734, 75th: 0.680818, max: 1.33133, mean: 0.501799
				4: min: 0, 25th: 0.345546, median: 0.448115, 75th: 0.516629, max: 1.61413, mean: 0.516495
				5: min: 0, 25th: 0.281746, median: 0.389395, 75th: 0.650756, max: 1.38689, mean: 0.456794
				6: min: 0, 25th: 0.399525, median: 0.498277, 75th: 0.768938, max: 1.52679, mean: 0.559861
				7: min: 0, 25th: 0.380261, median: 0.558404, 75th: 0.725864, max: 1.41669, mean: 0.551345
				8: min: 0, 25th: 0.375398, median: 0.503824, 75th: 0.658286, max: 1.36733, mean: 0.523584
				9: min: 0, 25th: 0.3829, median: 0.47189, 75th: 0.528937, max: 1.40057, mean: 0.504474
```
where `compute_exactly` is `N` for build step and `N*k` for swap step.

I have also updated the log file for `BanditPAM` algorithm to give min, max, mean and Q1, Q2 and Q3 quantiles for `sigma`. I tested it using the same example but change the algorithm to `BanditPAM`:

<img width="1094" alt="Screen Shot 2021-07-11 at 12 11 48 PM" src="https://user-images.githubusercontent.com/25496074/125202345-341d0200-e241-11eb-8e82-a989598cee90.png">

The corresponding log file is

```
Built:891,392,354,714,23,805,889,895,773,514
Swapped:694,800,306,714,324,959,737,527,168,251
Num Swaps: 18
Final Loss: 7.44375
Build Logstring:
		:compute_exactly
				0: 102
				1: 402
				2: 141
				3: 308
				4: 351
				5: 159
				6: 3
				7: 1
				8: 2
				9: 110
				10: 164
				11: 19
				12: 1
				13: 1
				14: 98
				15: 64
		:loss
				0: 8.97142
				1: 8.64027
				2: 8.40195
				3: 8.21948
				4: 8.05052
				5: 7.91262
				6: 7.8699
				7: 7.85371
				8: 7.83689
				9: 7.80006
		:p
				0: 1e-06
				1: 1e-06
				2: 1e-06
				3: 1e-06
				4: 1e-06
				5: 1e-06
				6: 1e-06
				7: 1e-06
				8: 1e-06
				9: 1e-06
		:sigma
				0: min: 0.489725, 25th: 1.01001, median: 1.16105, 75th: 1.37448, max: 2.18534, mean: 1.21614
				1: min: 0, 25th: 0.329301, median: 0.43944, 75th: 0.620751, max: 1.45303, mean: 0.500551
				2: min: 0, 25th: 0.211693, median: 0.299488, 75th: 0.429835, max: 1.2432, mean: 0.355215
				3: min: 0, 25th: 0.194888, median: 0.293789, 75th: 0.412053, max: 1.13846, mean: 0.339608
				4: min: 0, 25th: 0.162941, median: 0.258309, 75th: 0.386053, max: 1.1965, mean: 0.321567
				5: min: 0, 25th: 0.120902, median: 0.208138, 75th: 0.316022, max: 1.11665, mean: 0.26534
				6: min: 0, 25th: 0.0976279, median: 0.18033, 75th: 0.296182, max: 1.14531, mean: 0.24199
				7: min: 0, 25th: 0.0993143, median: 0.175913, 75th: 0.273412, max: 1.25484, mean: 0.236597
				8: min: 0, 25th: 0.103278, median: 0.181108, 75th: 0.312523, max: 1.13274, mean: 0.245477
				9: min: 0, 25th: 0.0971964, median: 0.173523, 75th: 0.29656, max: 1.09669, mean: 0.24168
Swap Logstring:
		:compute_exactly
				0: 459
				1: 1075
				2: 11
				3: 2
				4: 1313
				5: 70
				6: 21
				7: 2
				8: 4086
				9: 16
				10: 2
				11: 3247
				12: 114
				13: 4160
				14: 51
				15: 29
				16: 4
				17: 4823
				18: 106
				19: 84
				20: 2
				21: 5203
				22: 2976
				23: 133
				24: 13
				25: 9
				26: 3089
				27: 87
				28: 2
				29: 3
				30: 4
				31: 1
				32: 4203
				33: 2866
				34: 30
				35: 22
				36: 1
				37: 2
				38: 2977
				39: 54
				40: 3953
				41: 6
				42: 3205
				43: 157
				44: 4353
				45: 3971
				46: 5
				47: 19
				48: 43
				49: 31
				50: 2814
				51: 269
				52: 167
				53: 30
		:loss
				0: 7.79434
				1: 7.71383
				2: 7.64341
				3: 7.58656
				4: 7.54431
				5: 7.52869
				6: 7.51387
				7: 7.508
				8: 7.49392
				9: 7.48504
				10: 7.48205
				11: 7.47287
				12: 7.47159
				13: 7.47098
				14: 7.46502
				15: 7.4616
				16: 7.44375
				17: 7.44375
		:p
				0: 1e-08
				1: 1e-08
				2: 1e-08
				3: 1e-08
				4: 1e-08
				5: 1e-08
				6: 1e-08
				7: 1e-08
				8: 1e-08
				9: 1e-08
				10: 1e-08
				11: 1e-08
				12: 1e-08
				13: 1e-08
				14: 1e-08
				15: 1e-08
				16: 1e-08
				17: 1e-08
		:sigma
				0: min: 0, 25th: 0.22659, median: 0.464356, 75th: 0.600482, max: 1.32227, mean: 0.444284
				1: min: 0, 25th: 0.23883, median: 0.43435, 75th: 0.652561, max: 1.33791, mean: 0.455718
				2: min: 0, 25th: 0.26621, median: 0.497937, 75th: 0.63725, max: 1.50641, mean: 0.494403
				3: min: 0, 25th: 0.357039, median: 0.559158, 75th: 0.771347, max: 1.51537, mean: 0.597208
				4: min: 0, 25th: 0.320336, median: 0.508723, 75th: 0.761756, max: 1.52999, mean: 0.571268
				5: min: 0, 25th: 0.313067, median: 0.3995, 75th: 0.474545, max: 1.56443, mean: 0.480896
				6: min: 0, 25th: 0.323137, median: 0.463166, 75th: 0.689054, max: 1.58277, mean: 0.53452
				7: min: 0, 25th: 0.376203, median: 0.499665, 75th: 0.555863, max: 1.33211, mean: 0.486506
				8: min: 0, 25th: 0.368341, median: 0.479433, 75th: 0.590084, max: 1.34519, mean: 0.496368
				9: min: 0, 25th: 0.235824, median: 0.41224, 75th: 0.726722, max: 1.61524, mean: 0.505572
				10: min: 0, 25th: 0.365997, median: 0.45593, 75th: 0.831057, max: 1.52752, mean: 0.566196
				11: min: 0, 25th: 0.3034, median: 0.399324, 75th: 0.477273, max: 1.25356, mean: 0.420495
				12: min: 0, 25th: 0.343033, median: 0.462371, 75th: 0.694819, max: 1.52657, mean: 0.523975
				13: min: 0, 25th: 0.405971, median: 0.529201, 75th: 0.674025, max: 1.35328, mean: 0.566018
				14: min: 0, 25th: 0.348121, median: 0.494486, 75th: 0.578926, max: 1.4723, mean: 0.517232
				15: min: 0, 25th: 0.424065, median: 0.488008, 75th: 0.736142, max: 1.3858, mean: 0.559225
				16: min: 0, 25th: 0.356076, median: 0.483358, 75th: 0.783588, max: 1.5328, mean: 0.565501
				17: min: 0, 25th: 0.330451, median: 0.431363, 75th: 0.537489, max: 1.45189, mean: 0.486291
```


