### PR TITLE
remove duplicated code on loss in main. Fixes #60

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,9 +57,6 @@ int main(int argc, char* argv[])
             // type of loss/distance function to use
             case 'l':
                 loss = optarg;
-                if (std::regex_match(loss, std::regex("L\\d*"))) {
-                  loss = loss.substr(1);
-                }
                 break;
             // set the verbosity of the algorithm
             case 'v':


### PR DESCRIPTION
Remove the loss parsing part in `main.cpp`. This part is handled in `setLossFn()` function in `kmedoids_ucb.cpp` so we don't need to duplicate it in `main`:
https://github.com/ThrunGroup/BanditPAM/blob/c5f9760e7c4a59b9381119545897adcd6516f06a/src/kmedoids_ucb.cpp#L111-L114

I have tested  all the cases and got the expected results:
```
(base) thomascheung@Thomass-MacBook-Pro src % ./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1 -l cos
Medoids: 567,182,839,340,385,979,915,758,609,649
(base) thomascheung@Thomass-MacBook-Pro src % ./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1       
Medoids: 694,800,306,714,324,959,737,527,168,251
(base) thomascheung@Thomass-MacBook-Pro src % ./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1 -l L15
Medoids: 194,319,558,60,133,896,448,475,251,354
(base) thomascheung@Thomass-MacBook-Pro src % ./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1 -l manhattan
Medoids: 737,246,527,168,714,306,838,324,959,800
(base) thomascheung@Thomass-MacBook-Pro src % ./BanditPAM -f ../../data/MNIST-1k.csv -k 10 -v 1 -l inf  
Medoids: 725,461,625,856,993,773,492,444,354,24
```
