### PR TITLE
Modify naive algorithm to PAM. Fixes #1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(${PROJECT_SOURCE_DIR}/headers/carma)
 include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include)
 include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include/carma)
 include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include/carma/carma)
+include_directories(/Users/thomascheung/opt/anaconda3/pkgs/python-3.8.5-h26836e1_1/include/python3.8)
 
 add_executable(BanditPAM main.cpp)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,6 @@ include_directories(${PROJECT_SOURCE_DIR}/headers/carma)
 include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include)
 include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include/carma)
 include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include/carma/carma)
-include_directories(/Users/thomascheung/opt/anaconda3/pkgs/python-3.8.5-h26836e1_1/include/python3.8)
 
 add_executable(BanditPAM main.cpp)
 

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -275,7 +275,7 @@ void KMedoids::fit_naive(arma::mat input_data) {
   bool medoidChange = true;
   while (i < max_iter && medoidChange) {
     auto previous(medoid_indices);
-    // runs swa step as necessary
+    // runs swap step as necessary
     KMedoids::swap_naive(data, medoid_indices, assignments);
     medoidChange = arma::any(medoid_indices != previous);
     i++;
@@ -329,10 +329,10 @@ void KMedoids::build_naive(
         best = i;
       }
     }
-    // updates the medoid index for that of lowest cost.
+    // update the medoid index for that of lowest cost
     medoid_indices(k) = best;
 
-    // updates the best distance with this medoid 
+    // update the medoid assignment and best_distance for this datapoint
     for (size_t l = 0; l < N; l++) {
         double cost = (this->*lossFn)(data, l, medoid_indices(k));
         if (cost < best_distances(l)) {
@@ -402,8 +402,10 @@ void KMedoids::swap_naive(
           if (best_distances(j) < cost) {
             cost = best_distances(j);
           }
-        } else if (second_distances(j) < cost) {
+        } else {
+          if (second_distances(j) < cost) {
           cost = second_distances(j);
+          }
         } 
         total += cost;
       }

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -318,12 +318,9 @@ void KMedoids::build_naive(
       for (size_t j = 0; j < data.n_cols; j++) {
         // computes distance between base and all other points
         double cost = (this->*lossFn)(data, i, j);
-        for (size_t medoid = 0; medoid < k; medoid++) {
-          double current = (this->*lossFn)(data, medoid_indices(medoid), j);
-          // compares this for cost of the medoid
-          if (current < cost) {
-            cost = current;
-          }
+        // compares this with the cached best distance
+        if (best_distances(j) < cost) {
+          cost = best_distances(j);
         }
         total += cost;
       }
@@ -335,7 +332,7 @@ void KMedoids::build_naive(
     // updates the medoid index for that of lowest cost.
     medoid_indices(k) = best;
 
-    // don't need to do this on final iteration
+    // updates the best distance with this medoid 
     for (size_t l = 0; l < N; l++) {
         double cost = (this->*lossFn)(data, l, medoid_indices(k));
         if (cost < best_distances(l)) {
@@ -399,15 +396,15 @@ void KMedoids::swap_naive(
       for (size_t j = 0; j < data.n_cols; j++) {
         // compute distance between base point and every other datapoint
         double cost = (this->*lossFn)(data, i, j);
-        for (size_t medoid = 0; medoid < n_medoids; medoid++) {
-          if (medoid == k) {
-            continue;
+        // (i) if x_j is not assigned to k: compares this with the cached best distance 
+        // (ii) if x_j is assigned to k: compares this with the cached second best distance
+        if (assignments(j) != k) {
+          if (best_distances(j) < cost) {
+            cost = best_distances(j);
           }
-          double current = (this->*lossFn)(data, medoid_indices(medoid), j);
-          if (current < cost) {
-            cost = current;
-          }
-        }
+        } else if (second_distances(j) < cost) {
+          cost = second_distances(j);
+        } 
         total += cost;
       }
       // if total distance for new base point is better than that of the medoid,


### PR DESCRIPTION
I have modified the naive algorithm to PAM. The logic of `swap_naive`  is changed so that the best and second best distance of each datapoint are cached and used in the computing the cost. When we swap medoid m_k with non-medoid x_i, the cost for datapoint x_j is computed as

1. if x_j is assigned to medoid m_k: cost = min(dist(x_i, x_j), second best distance of j)
2. if x_j is not assigned to medoid m_k: cost = min(dist(x_i, x_j), best distance of j)

Hence, the complexity of PAM is O(kn^2) . The algorithms are tested on the MNIST-1k data as follows:

`Original naive algorithm`
<img width="1040" alt="Screen Shot 2021-07-24 at 12 07 09 PM" src="https://user-images.githubusercontent.com/25496074/126876663-f33c2f47-a1ef-4b8b-b21c-20a5cf538453.png">

`PAM algorithm`
<img width="1035" alt="Screen Shot 2021-07-24 at 12 09 13 PM" src="https://user-images.githubusercontent.com/25496074/126876672-d9e3bc33-ef66-4bb2-866a-db211cced4e3.png">
