### PR TITLE
Updating scripts to avoid re-running things that don't need to be re-run. Fix for issue #13

### DIFF
--- a/env_setup.sh
+++ b/env_setup.sh
@@ -27,8 +27,21 @@ mkdir -p data
 [[ ! -f ./data/MNIST-70k.csv ]] && "Downloading full MNIST..." && download http://web.stanford.edu/~ericsf/MNIST-70k.csv ./data/MNIST-70k.csv
 
 ######### Run scripts #########
-echo "Running build_docker.sh"
-sh ./build_docker.sh
-echo "Running install-hooks.sh"
-sh scripts/install-hooks.sh
+
+if [[ "$(docker images -q banditpam/cpp:latest 2> /dev/null)" == "" ]]; then
+  echo "Running build_docker.sh"
+  sh ./build_docker.sh
+else
+  echo "Docker image banditpam/cpp:latest already exists. Skipping execution of build_docker.sh."
+fi
+
+GIT_DIR=$(git rev-parse --git-dir)
+
+if [[ -f $GIT_DIR/hooks/pre-push && -f $GIT_DIR/hooks/pre-commit ]]; then
+   echo "Hooks already exist. Skipping execution of scripts/install-hooks.sh."
+else
+   echo "Runnin install-hooks.sh"
+   sh scripts/install-hooks.sh
+fi
+
 echo "Done"

--- a/scripts/hook.sh
+++ b/scripts/hook.sh
@@ -2,10 +2,10 @@
 cd "${0%/*}/../.."
 echo 'Running tests'
 
-python3 tests/test_push.py
+python3 tests/test_commit.py
 if [ $? -ne 0 ]; then
-	echo 'Aborting push (Attempting to push a repository where the test suite fails)'
-	echo 'Bypass with git push --no-verify'
+	echo 'Aborting commit (Attempting to commit a repository where the test suite fails)'
+	echo 'Bypass with git commit --no-verify'
 	exit 1
 fi
 

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -6,10 +6,14 @@
 GIT_DIR=$(git rev-parse --git-dir)
 
 echo "Installing hooks..."
-cp ./scripts/hook.sh $GIT_DIR/hooks/pre-commit
+cp ./scripts/template_hook.sh $GIT_DIR/hooks/pre-commit
 chmod +x $GIT_DIR/hooks/pre-commit
-sed -i '' 's/commit/push/g' scripts/hook.sh
-cp ./scripts/hook.sh $GIT_DIR/hooks/pre-push
+
+sed -i -e 's/<stage>/commit/g' $GIT_DIR/hooks/pre-commit
+
+cp ./scripts/template_hook.sh $GIT_DIR/hooks/pre-push
 chmod +x $GIT_DIR/hooks/pre-push
+
+sed -i -e 's/<stage>/push/g' $GIT_DIR/hooks/pre-push
 
 echo "Done!"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -8,7 +8,7 @@ GIT_DIR=$(git rev-parse --git-dir)
 echo "Installing hooks..."
 cp ./scripts/hook.sh $GIT_DIR/hooks/pre-commit
 chmod +x $GIT_DIR/hooks/pre-commit
-sed -i 's/commit/push/g' ./scripts/hook.sh
+sed -i '' 's/commit/push/g' scripts/hook.sh
 cp ./scripts/hook.sh $GIT_DIR/hooks/pre-push
 chmod +x $GIT_DIR/hooks/pre-push
 

--- a/scripts/template_hook.sh
+++ b/scripts/template_hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+cd "${0%/*}/../.."
+echo 'Running tests'
+
+python3 tests/test_<stage>.py
+if [ $? -ne 0 ]; then
+	echo 'Aborting <stage> (Attempting to <stage> a repository where the test suite fails)'
+	echo 'Bypass with git <stage> --no-verify'
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Please review the Pull request for issue #13.  Updating scripts (env_setup.sh) to avoid re-running things that don't need to be re-run. 
- Modified the file `env_setup.sh`  to check the below two items:
   1) If docker image `banditpam/cpp:latest` already exists, skip the creation of docker image
   2) If pre-commit and pre-push hooks already exists, skip the creation of hooks
- Modified the file `scripts/install-hooks.sh` to fix the error in 'sed' command.
- Below tests are executed to validate above items
     1) Ran the `env_setup.sh` when docker image does not exists 
     2) Ran the `env_setup.sh` when docker image already exists 
     3) Ran the `env_setup.sh` when `pre-commit` and `pre-push` hooks do not exist
     4) Ran the ` env_setup.sh` when `pre-commit` and `pre-push` hooks already exist
- Modified the file  ```scripts/hook.sh``` to execute the corresponding test cases on ```push``` and ```commit``` operations

