### PR TITLE
Modifying `setup.py` to be specific to OSX, Ubuntu, and other Linux distros

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -237,11 +237,18 @@ class BuildExt(build_ext):
 # TODO: Edit libraries based on gcc vs clang
 # TODO: Edit language based on gcc vs clang
 # TODO: Edit include_dirs based on OS
-ext_modules = [
-    Extension(
-        'BanditPAM',
-        [os.path.join('src', 'kmeds_pywrapper.cpp'), os.path.join('src', 'kmedoids_ucb.cpp')],
-        include_dirs=[
+
+if sys.platform == 'linux' or sys.platform == 'linux2':
+    include_dirs=[
+            get_pybind_include(),
+            get_numpy_include(),
+            'headers',
+            '/usr/local/include',
+            '/usr/local/include/carma',
+            '/usr/local/include/carma/carma',
+        ]
+else: # including for MacOSX / darwin
+    include_dirs=[
             get_pybind_include(),
             get_numpy_include(),
             'headers',
@@ -249,7 +256,14 @@ ext_modules = [
             'headers/carma/include/carma',
             'headers/carma/include/carma/carma',
             '/usr/local/include',
-        ],
+        ]
+
+
+ext_modules = [
+    Extension(
+        'BanditPAM',
+        [os.path.join('src', 'kmeds_pywrapper.cpp'), os.path.join('src', 'kmedoids_ucb.cpp')],
+        include_dirs=include_dirs,
         library_dirs=[
             '/usr/local/lib',
         ],

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def cpp_flag(compiler):
     The newer version is prefered over c++11 (when it is available).
     '''
     flags = ['-std=c++17', '-std=c++14', '-std=c++11']
-    #flags = ['-std=c++1y']
+    #flags = ['-std=c++14']
     
     for flag in flags:
         if has_flag(compiler, flag):
@@ -213,7 +213,7 @@ class BuildExt(build_ext):
         link_opts = self.l_opts.get(ct, [])
         
         opts.append('-Wno-register')
-        opts.append('-std=c++1y')
+        opts.append('-std=c++14')
         opts.append('-O3') # Add it here as well, in case of Windows installation
         
         if sys.platform == 'darwin':
@@ -254,7 +254,7 @@ ext_modules = [
             '/usr/local/lib',
         ],
         libraries=['armadillo', 'omp'],
-        language='c++1y',
+        language='c++14',
         extra_compile_args=['-static-libstdc++'],
     ),
 ]

--- a/setup.py
+++ b/setup.py
@@ -136,12 +136,6 @@ def check_armadillo_install_linux():
     return output.decode().strip()
 
 
-def check_carma_install_linux():
-    if not os.path.exists(os.path.join('usr', 'local', 'include', 'carma')):
-        raise Exception("Error: carma does not appear to be installed. \
-            Did you build it from %s ?" % (os.path.join('BanditPAM', 'headers', 'carma', 'third_party', 'armadillo-code')))
-
-
 def check_linux_package_installation(pkg_name):
     cmd = ['dpkg', '-s', pkg_name]
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
@@ -183,9 +177,6 @@ def install_check_linux():
     # Check armadillo is installed
     check_armadillo_install_linux()
 
-    # Check carma is installed
-    check_carma_install_linux()
-    
 class BuildExt(build_ext):
     '''
     A custom build extension for adding compiler-specific options.

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 import setuptools
 import subprocess
+import platform
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 
@@ -148,7 +149,7 @@ def check_linux_package_installation(pkg_name):
     return output.decode().strip()
 
 
-def install_check_linux():
+def install_check_ubuntu():
     # Make sure linux packages are installed
     dependencies = [
         'build-essential',
@@ -177,6 +178,12 @@ def install_check_linux():
     # Check armadillo is installed
     check_armadillo_install_linux()
 
+def is_ubuntu():
+    cmd = ['cat', '/etc/issue']
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    output, _error = process.communicate()
+    return 'Ubuntu' in output.decode()
+
 class BuildExt(build_ext):
     '''
     A custom build extension for adding compiler-specific options.
@@ -197,7 +204,8 @@ class BuildExt(build_ext):
         c_opts['unix'] += darwin_opts
         l_opts['unix'] += darwin_opts
     elif sys.platform == 'linux' or sys.platform =='linux2':
-        install_check_linux()
+        if is_ubuntu():
+            install_check_ubuntu()
 
         linux_opts = ['-O3']
         c_opts['unix'] += linux_opts


### PR DESCRIPTION
This PR makes several changes to `setup.py` to ensure it is run correctly on OSX, Ubuntu, and other Linux distros:

- Modifying the `include_dirs` based on OS
- Modifying the necessary `libraries` based on OS
- Checking for the necessary dependencies on each platform
- Modifying the compiler flags based on OS