### PR TITLE
Updated the cpp code to catch the ctrl_c interruption. Fix for issue #21.

### DIFF
--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -17,13 +17,12 @@
 /**
  *  \brief Kills the process.
  * 
- * Check whether ctrl+c signal is received.
- * If signal is received it kilss the process.
+ *  Terminates the process if ctrl+c signal is received
+ * 
  */
  
 void signal_callback_handler(int signum) {
    std::cout << "Caught signal " << signum << std::endl;
-   // Terminate program
    exit(signum);
 }
 

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -12,6 +12,20 @@
 #include <unordered_map>
 #include <regex>
 //#include <sstream>
+#include <signal.h>
+
+/**
+ *  \brief Kills the process.
+ * 
+ * Check whether ctrl+c signal is received.
+ * If signal is received it kilss the process.
+ */
+ 
+void signal_callback_handler(int signum) {
+   std::cout << "Caught signal " << signum << std::endl;
+   // Terminate program
+   exit(signum);
+}
 
 /**
  *  \brief Class implementation for running KMedoids methods.
@@ -35,6 +49,7 @@ KMedoids::KMedoids(int n_medoids, std::string algorithm, int verbosity,
        verbosity(verbosity),
        logFilename(logFilename) {
   KMedoids::checkAlgorithm(algorithm);
+  signal(SIGINT, signal_callback_handler);
 }
 
 /**
@@ -43,6 +58,7 @@ KMedoids::KMedoids(int n_medoids, std::string algorithm, int verbosity,
  *  Destructor for the KMedoids class.
  */
 KMedoids::~KMedoids() {;}
+
 
 /**
  *  \brief Checks whether algorithm input is valid
@@ -242,7 +258,7 @@ void KMedoids::setLogFilename(std::string new_lname) {
  * @param input_data Input data to find the medoids of
  * @param loss The loss function used during medoid computation
  */
-void KMedoids::fit(arma::mat input_data, std::string loss) {
+void KMedoids::fit(arma::mat input_data, std::string loss) { 
   KMedoids::setLossFn(loss);
   (this->*fitFn)(input_data);
   if (verbosity > 0) {

--- a/src/kmedoids_ucb.cpp
+++ b/src/kmedoids_ucb.cpp
@@ -58,7 +58,6 @@ KMedoids::KMedoids(int n_medoids, std::string algorithm, int verbosity,
  */
 KMedoids::~KMedoids() {;}
 
-
 /**
  *  \brief Checks whether algorithm input is valid
  *
@@ -257,7 +256,7 @@ void KMedoids::setLogFilename(std::string new_lname) {
  * @param input_data Input data to find the medoids of
  * @param loss The loss function used during medoid computation
  */
-void KMedoids::fit(arma::mat input_data, std::string loss) { 
+void KMedoids::fit(arma::mat input_data, std::string loss) {
   KMedoids::setLossFn(loss);
   (this->*fitFn)(input_data);
   if (verbosity > 0) {


### PR DESCRIPTION
This is the fix for issue #21.

- Modified the file `kmedoids_ucb.cpp` and added the method `signal_callback_handler`  for signal handling. 
- If CPP code is being executed and code gets the `ctrl+c` signal, it will execute this method to terminate the running process.
- This code is only handle the `ctrl+c` event when CPP code is running. I noticed that in the test cases we are reading large csv files in python code and it takes a while to finish that execution. This code does not handle that situation.
- Test case : If I am executing the test cases or any other examples and CPP code is taking a long time, if i give `ctrl+c` my process gets killed immediately with the message `^CCaught signal 2`
