### PR TITLE
Updating the `Dockerfile` to fix the error in `env_setup.sh` execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,10 @@ RUN cd /home/armadillo-code \
     && cd .. \
     && rm -rf armadillo-code
 
-RUN cd /home/carma \
-    && git checkout unstable \
+RUN yum -y install git-all \
+    && export PATH=/usr/local/libexec/git-core:$PATH \
+    &&  cd /home/carma \
+    && git checkout 502ab50 \
     && git submodule update --init \
     && mkdir build \
     && cd build \


### PR DESCRIPTION
This is the fix for issue #12.
To execute the `env_setup.sh` successfully, local instance of Docker must be installed and running

- Updated the code for checking out specific commit of `carma` : from `git checkout unstable` to `git checkout 502ab50`. That's the commit version currently working properly with BanditPAM.

- Added the below code to fix the SSL error in the execution of `env_setup.sh`
  `yum -y install git-all` 
  `export PATH=/usr/local/libexec/git-core:$PATH`

 - After making these changes I can execute `env_setup.sh` successfully.

BanditPAM % docker images                       
REPOSITORY      TAG       IMAGE ID       CREATED              SIZE
banditpam/cpp   latest    03d9521c9f7b   About a minute ago   3.5GB