### PR TITLE
Implement FastPAM1. Fixes #106

### DIFF
--- a/headers/fastpam1.hpp
+++ b/headers/fastpam1.hpp
@@ -1,0 +1,61 @@
+#ifndef FASTPAM1_H_
+#define FASTPAM1_H_
+
+#include "kmedoids_algorithm.hpp"
+#include "log_helper.hpp"
+
+#include <carma>
+#include <armadillo>
+#include <vector>
+#include <fstream>
+#include <iostream>
+#include <chrono>
+#include <omp.h>
+
+/**
+ *  \brief Class implementation for FastPAM1 algorithm. 
+ *
+ *  FastPAM1 class. Consists of all necessary functions to implement 
+ *  FastPAM1 algorithm. 
+ *  
+ */
+class FastPAM1 : public km::KMedoids {
+public:
+    /*! \brief Runs FastPAM1 algorithm.
+    * 
+    *  Run the FastPAM1 algorithm to identify a dataset's medoids.
+    *
+    *  @param input_data Input data to cluster
+    */
+    void fit_fastpam1(const arma::mat& input_data);
+
+    /*! \brief Build step for the FastPAM1 algorithm
+    *
+    *  Runs build step for the FastPAM1 algorithm. Loops over all datapoint and
+    *  checks its distance from every other datapoint in the dataset, then checks if
+    *  the total cost is less than that of the medoid (if a medoid exists yet).
+    *
+    *  @param data Transposed input data to cluster
+    *  @param medoid_indices Uninitialized array of medoids that is modified in place
+    *  as medoids are identified
+    */
+    void build_fastpam1(const arma::mat& data, arma::rowvec& medoid_indices);
+
+    /*! \brief Swap step for the FastPAM1 algorithm
+    *
+    *  Runs swap step for the FastPAM1 algorithm. Loops over all datapoint and
+    *  compute the loss change when a medoid is replaced by the datapoint. The 
+    *  loss change is stored in an array of size n_medoids and the update is 
+    *  based on an if conditional outside of the loop. The best medoid is chosen
+    *  according to the best loss change. 
+    *
+    *  @param data Transposed input data to cluster
+    *  @param medoid_indices Array of medoid indices created from the build step
+    *  that is modified in place as better medoids are identified
+    *  @param assignments Uninitialized array of indices corresponding to each
+    *  datapoint assigned the index of the medoid it is closest to
+    */
+    void swap_fastpam1(const arma::mat& data, arma::rowvec& medoid_indices, arma::rowvec& assignments);
+};
+
+#endif // FASTPAM1_H_

--- a/headers/kmedoids_algorithm.hpp
+++ b/headers/kmedoids_algorithm.hpp
@@ -94,10 +94,16 @@ namespace km {
     private:
       // The functions below are PAM's constituent functions
       void fit_bpam(const arma::mat& inputData);
+    
+      void fit_fastpam1(const arma::mat& inputData);
 
       void fit_naive(const arma::mat& inputData); // pass by ref? (and above)
 
       void build_naive(const arma::mat& data, arma::rowvec& medoidIndices);
+
+      void build_fastpam1(const arma::mat& data, arma::rowvec& medoidIndices);
+
+      void swap_fastpam1(const arma::mat& data, arma::rowvec& medoidIndices, arma::rowvec& assignments);
 
       void swap_naive(const arma::mat& data, arma::rowvec& medoidIndices, arma::rowvec& assignments);
 

--- a/headers/kmedoids_algorithm.hpp
+++ b/headers/kmedoids_algorithm.hpp
@@ -94,18 +94,18 @@ namespace km {
     private:
       // The functions below are PAM's constituent functions
       void fit_bpam(const arma::mat& inputData);
-    
-      void fit_fastpam1(const arma::mat& inputData);
 
       void fit_naive(const arma::mat& inputData); // pass by ref? (and above)
 
       void build_naive(const arma::mat& data, arma::rowvec& medoidIndices);
 
+      void swap_naive(const arma::mat& data, arma::rowvec& medoidIndices, arma::rowvec& assignments);
+
+      void fit_fastpam1(const arma::mat& inputData);
+
       void build_fastpam1(const arma::mat& data, arma::rowvec& medoidIndices);
 
       void swap_fastpam1(const arma::mat& data, arma::rowvec& medoidIndices, arma::rowvec& assignments);
-
-      void swap_naive(const arma::mat& data, arma::rowvec& medoidIndices, arma::rowvec& assignments);
 
       void build(
         const arma::mat& data,

--- a/headers/kmedoids_algorithm.hpp
+++ b/headers/kmedoids_algorithm.hpp
@@ -90,9 +90,9 @@ namespace km {
 
       void setLossFn(std::string loss);
 
-      
-    private:
+    protected:
       // The functions below are PAM's constituent functions
+
       void fit_bpam(const arma::mat& inputData);
 
       void fit_naive(const arma::mat& inputData); // pass by ref? (and above)
@@ -100,12 +100,6 @@ namespace km {
       void build_naive(const arma::mat& data, arma::rowvec& medoidIndices);
 
       void swap_naive(const arma::mat& data, arma::rowvec& medoidIndices, arma::rowvec& assignments);
-
-      void fit_fastpam1(const arma::mat& inputData);
-
-      void build_fastpam1(const arma::mat& data, arma::rowvec& medoidIndices);
-
-      void swap_fastpam1(const arma::mat& data, arma::rowvec& medoidIndices, arma::rowvec& assignments);
 
       void build(
         const arma::mat& data,
@@ -199,8 +193,6 @@ namespace km {
 
       double (KMedoids::*lossFn)(const arma::mat& data, size_t i, size_t j) const; ///< loss function used during KMedoids::fit
 
-      void (KMedoids::*fitFn)(const arma::mat& inputData); ///< function used for finding medoids (from algorithm)
-
       LogHelper logHelper; ///< helper object for making formatted logs
 
       size_t steps; ///< number of actual swap iterations taken by the algorithm
@@ -219,5 +211,4 @@ namespace km {
       std::string logFilename; ///< name of the logfile output (verbosity permitting)
   };
 }
-
-  #endif // KMEDOIDS_ALGORITHM_H_
+#endif // KMEDOIDS_ALGORITHM_H_

--- a/setup.py
+++ b/setup.py
@@ -274,7 +274,8 @@ ext_modules = [
         [os.path.join('src', 'kmedoids_pywrapper.cpp'), 
          os.path.join('src', 'kmedoids_algorithm.cpp'),
          os.path.join('src', 'pam.cpp'),
-         os.path.join('src', 'banditpam.cpp')],
+         os.path.join('src', 'banditpam.cpp'),
+         os.path.join('src', 'fastpam1.cpp')],
         include_dirs=include_dirs,
         library_dirs=[
             '/usr/local/lib',

--- a/setup.py
+++ b/setup.py
@@ -275,7 +275,8 @@ ext_modules = [
          os.path.join('src', 'kmedoids_algorithm.cpp'),
          os.path.join('src', 'pam.cpp'),
          os.path.join('src', 'banditpam.cpp'),
-         os.path.join('src', 'fastpam1.cpp')],
+         os.path.join('src', 'fastpam1.cpp'),
+        ],
         include_dirs=include_dirs,
         library_dirs=[
             '/usr/local/lib',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(${PROJECT_SOURCE_DIR}/headers/carma/include/carma_bits)
 
 add_executable(BanditPAM main.cpp)
 
-add_library(BanditPAM_LIB kmedoids_algorithm.cpp pam.cpp banditpam.cpp)
+add_library(BanditPAM_LIB kmedoids_algorithm.cpp pam.cpp banditpam.cpp fastpam1.cpp)
 target_link_libraries(BanditPAM PUBLIC BanditPAM_LIB)
 
 find_package(OpenMP REQUIRED)

--- a/src/fastpam1.cpp
+++ b/src/fastpam1.cpp
@@ -1,0 +1,194 @@
+/**
+ * @file fastpam1.cpp
+ * @date 2021-08-03
+ *
+ * This file contains the primary C++ implementation of the FastPAM1 code.
+ *
+ */
+#include "kmedoids_algorithm.hpp"
+#include "log_helper.hpp"
+
+#include <carma.h>
+#include <armadillo>
+#include <unordered_map>
+#include <regex>
+
+/**
+ * \brief Runs naive FastPAM1 algorithm.
+ *
+ * Run the naive FastPAM1 algorithm to identify a dataset's medoids.
+ *
+ * @param input_data Input data to find the medoids of
+ */
+void km::KMedoids::fit_fastpam1(const arma::mat& input_data) {
+  data = input_data;
+  data = arma::trans(data);
+  arma::rowvec medoid_indices(n_medoids);
+  // runs build step
+  km::KMedoids::build_fastpam1(data, medoid_indices);
+  steps = 0;
+  medoid_indices_build = medoid_indices;
+  arma::rowvec assignments(data.n_cols);
+  size_t iter = 0;
+  bool medoidChange = true;
+  while (iter < max_iter && medoidChange) {
+    auto previous(medoid_indices);
+    // runs swap step as necessary
+    km::KMedoids::swap_fastpam1(data, medoid_indices, assignments);
+    medoidChange = arma::any(medoid_indices != previous);
+    iter++;
+  }
+  medoid_indices_final = medoid_indices;
+  labels = assignments;
+  steps = iter;
+}
+
+/**
+ * \brief Build step for the FastPAM1 algorithm
+ *
+ * Runs build step for the FastPAM1 algorithm. Loops over all datapoint and
+ * checks its distance from every other datapoint in the dataset, then checks if
+ * the total cost is less than that of the medoid (if a medoid exists yet).
+ *
+ * @param data Transposed input data to find the medoids of
+ * @param medoid_indices Uninitialized array of medoids that is modified in place
+ * as medoids are identified
+ */
+void km::KMedoids::build_fastpam1(
+  const arma::mat& data, 
+  arma::rowvec& medoid_indices)
+{ 
+  size_t N = data.n_cols;
+  int p = (buildConfidence * N); // reciprocal
+  bool use_absolute = true;
+  arma::rowvec estimates(N, arma::fill::zeros);
+  arma::rowvec best_distances(N);
+  best_distances.fill(std::numeric_limits<double>::infinity());
+  arma::rowvec sigma(N); // standard deviation of induced losses on reference points
+  for (size_t k = 0; k < n_medoids; k++) {
+    double minDistance = std::numeric_limits<double>::infinity();
+    int best = 0;
+    km::KMedoids::build_sigma(
+           data, best_distances, sigma, batchSize, use_absolute); // computes std dev amongst batch of reference points
+    // fixes a base datapoint
+    for (int i = 0; i < data.n_cols; i++) {
+      double total = 0;
+      for (size_t j = 0; j < data.n_cols; j++) {
+        // computes distance between base and all other points
+        double cost = (this->*lossFn)(data, i, j);
+        // compares this with the cached best distance
+        if (best_distances(j) < cost) {
+          cost = best_distances(j);
+        }
+        total += cost;
+      }
+      if (total < minDistance) {
+        minDistance = total;
+        best = i;
+      }
+    }
+    // update the medoid index for that of lowest cost
+    medoid_indices(k) = best;
+
+    // update the medoid assignment and best_distance for this datapoint
+    for (size_t l = 0; l < N; l++) {
+        double cost = (this->*lossFn)(data, l, medoid_indices(k));
+        if (cost < best_distances(l)) {
+            best_distances(l) = cost;
+        }
+    }
+    use_absolute = false; // use difference of loss for sigma and sampling,
+                          // not absolute
+    logHelper.loss_build.push_back(minDistance/N);
+    logHelper.p_build.push_back((float)1/(float)p);
+    logHelper.comp_exact_build.push_back(N);
+  }
+}
+
+/**
+ * \brief Swap step for the FastPAM1 algorithm
+ *
+ * Runs swap step for the FastPAM1 algorithm. Loops over all datapoint and
+ * checks its distance from every other datapoint in the dataset, then checks if
+ * the total cost is less than that of the medoid.
+ *
+ * @param data Transposed input data to find the medoids of
+ * @param medoid_indices Array of medoid indices created from the build step
+ * that is modified in place as better medoids are identified
+ * @param assignments Uninitialized array of indices corresponding to each
+ * datapoint assigned the index of the medoid it is closest to
+ */
+void km::KMedoids::swap_fastpam1(
+  const arma::mat& data, 
+  arma::rowvec& medoid_indices,
+  arma::rowvec& assignments)
+{
+  double bestChange = 0; // best loss change 
+  double minDistance = std::numeric_limits<double>::infinity();
+  size_t best = 0;
+  size_t medoid_to_swap = 0;
+  size_t N = data.n_cols;
+  int p = (N * n_medoids * swapConfidence); // reciprocal
+  arma::mat sigma(n_medoids, N, arma::fill::zeros);
+  arma::rowvec best_distances(N);
+  arma::rowvec second_distances(N);
+  arma::rowvec delta_td(n_medoids, arma::fill::zeros);
+
+  // calculate quantities needed for swap, best_distances and sigma
+  calc_best_distances_swap(
+    data, medoid_indices, best_distances, second_distances, assignments);
+
+  swap_sigma(data,
+              sigma,
+              batchSize,
+              best_distances,
+              second_distances,
+              assignments);
+  
+  // write the sigma distribution to logfile
+  sigma_log(sigma);
+  // for every point in our dataset, let it serve as a new medoid 
+  for (size_t i = 0; i < data.n_cols; i++) {
+      double di = best_distances(i);
+      // loss change for making i a medoid
+      delta_td.fill(-di);
+      for (size_t j = 0; j < data.n_cols; j++) {
+          if (j != i) {
+              // compute distance to new medoid
+              double dij = (this->*lossFn)(data, i, j);
+              // update loss change for the current 
+              if (dij < second_distances(j)) {
+                  delta_td.at(assignments(j)) += (dij - best_distances(j));
+              } else {
+                  delta_td.at(assignments(j)) += (second_distances(j) - best_distances(j));
+              }
+              // reassignment check 
+              if (dij < best_distances(j)) {
+                  // update loss change for others 
+                  delta_td += (dij -  best_distances(j));
+                  // remove the update for the current
+                  delta_td.at(assignments(j)) -= (dij -  best_distances(j)); 
+              }  
+          }
+      }
+      // choose the best medoid-to-swap 
+      arma::uword min_medoid = delta_td.index_min();
+      // if the loss change is better than the best loss change
+      // update the best index identified so far
+      if (delta_td.min() < bestChange) {
+          bestChange = delta_td.min();
+          best = i;
+          medoid_to_swap = min_medoid;
+      }
+  }
+  // update the loss and medoid if the loss is improved
+  if (bestChange < 0) {
+      minDistance = arma::sum(best_distances) + bestChange;
+      medoid_indices(medoid_to_swap) = best;
+  } else {
+      minDistance = arma::sum(best_distances);
+  }
+  logHelper.loss_swap.push_back(minDistance/N);
+  logHelper.p_swap.push_back((float)1/(float)p);
+  logHelper.comp_exact_swap.push_back(N*n_medoids);
+}

--- a/src/kmedoids_algorithm.cpp
+++ b/src/kmedoids_algorithm.cpp
@@ -61,6 +61,8 @@ void km::KMedoids::checkAlgorithm(const std::string& algorithm) {
     fitFn = &km::KMedoids::fit_bpam;
   } else if (algorithm == "naive") {
     fitFn = &km::KMedoids::fit_naive;
+  } else if (algorithm == "FastPAM1") {
+    fitFn = &km::KMedoids::fit_fastpam1;
   } else {
     throw "unrecognized algorithm";
   }

--- a/src/kmedoids_pywrapper.cpp
+++ b/src/kmedoids_pywrapper.cpp
@@ -9,6 +9,7 @@
 
 #include "kmedoids_algorithm.hpp"
 #include "log_helper.hpp"
+#include "fastpam1.hpp"
 
 #include <carma>
 #include <armadillo>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 
 #include "kmedoids_algorithm.hpp"
 #include "log_helper.hpp"
+#include "fastpam1.hpp"
 
 #include <armadillo>
 #include <chrono>


### PR DESCRIPTION
I have implemented `FastPAM1` algorithm in this commit. The `FastPAM1` algorithm follows from Algorithm 3 of the PAM and FastPAM1 paper https://arxiv.org/pdf/1810.05691.pdf, where the core idea is to replace the iteration of `k` medoids in the `swap` step with an if conditional outside the loop. This is achievable by using an array to compute `k` loss changes which results in O(N^2) per iteration. 

The algorithm is tested against MNIST-1k dataset as shown below.

<img width="1084" alt="Screen Shot 2021-08-05 at 12 47 17 AM" src="https://user-images.githubusercontent.com/25496074/128376800-40b07204-4e93-407f-90a0-ae527c059a04.png">

It gives the expected set of medoids and the order of `k` is close of zero. 

