### PR TITLE
Give informative error message if no file is passed. Fixes #85

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <exception>
 #include <regex>
+#include <filesystem>
 
 int main(int argc, char* argv[])
 {   
@@ -78,7 +79,9 @@ int main(int argc, char* argv[])
         throw std::invalid_argument("error: Must specify input file via -f flag");
       } else if (!k_flag) {
         throw std::invalid_argument("error: Must specify number of clusters via -k flag");
-      } 
+      } else if (!std::filesystem::exists(input_name)) {
+        throw std::invalid_argument("error: The file does not exist");
+      }
     } catch (std::invalid_argument& e) {
       std::cout << e.what() << std::endl;
       return ARGUMENT_ERROR_CODE;


### PR DESCRIPTION
Updated the error message when the file is not passed/ not found. For instance, if the input file path is invalid, the program will give an error message as shown in the example below:
```
(base) thomascheung@Thomass-MacBook-Pro src % ./BanditPAM -f ../../data/MNIST-2k.csv -k 2 -v 1 
error: The file does not exist
```