### PR TITLE
Make global variable explicit and add optional argument for algorithm

### DIFF
--- a/src/kmedoids_algorithm.cpp
+++ b/src/kmedoids_algorithm.cpp
@@ -171,6 +171,7 @@ std::string km::KMedoids::getAlgorithm() {
  */
 void km::KMedoids::setAlgorithm(const std::string& new_alg) {
   algorithm = new_alg;
+  km::KMedoids::checkAlgorithm(algorithm);
 }
 
 /**
@@ -293,13 +294,12 @@ void km::KMedoids::setLogFilename(const std::string& new_lname) {
  */
 void km::KMedoids::fit(const arma::mat& input_data, const std::string& loss) {
   km::KMedoids::setLossFn(loss);
-  km::KMedoids::checkAlgorithm(algorithm);
   (this->*fitFn)(input_data);
-  if (verbosity > 0) {
-      logHelper.init(logFilename);
-      logHelper.writeProfile(medoid_indices_build, medoid_indices_final, steps,
-                                                        logHelper.loss_swap.back());
-      logHelper.close();
+  if (this->verbosity > 0) {
+      this->logHelper.init(this->logFilename);
+      this->logHelper.writeProfile(this->medoid_indices_build, this->medoid_indices_final, this->steps,
+                                                        this->logHelper.loss_swap.back());
+      this->logHelper.close();
   }
 }
 

--- a/src/kmedoids_pywrapper.cpp
+++ b/src/kmedoids_pywrapper.cpp
@@ -73,8 +73,13 @@ public:
       throw;
     }
     // if k is specified here, we set the number of medoids as k and override previous value 
-    if ((kw.size() != 0) && (kw.contains("k"))) {
-      KMedoids::setNMedoids(py::cast<int>(kw["k"]));
+    if (kw.size() != 0) {
+      if (kw.contains("k")) {
+        KMedoids::setNMedoids(py::cast<int>(kw["k"]));
+      }
+      if (kw.contains("algorithm")) {
+        KMedoids::setAlgorithm(py::cast<std::string>(kw["algorithm"]));
+      }
     }
     KMedoids::setLogFilename(logFilename);
     KMedoids::fit(carma::arr_to_mat<double>(inputData), loss);

--- a/src/pam.cpp
+++ b/src/pam.cpp
@@ -26,8 +26,6 @@ void km::KMedoids::fit_naive(const arma::mat& input_data) {
   arma::rowvec medoid_indices(n_medoids);
   // runs build step
   km::KMedoids::build_naive(data, medoid_indices);
-  steps = 0;
-
   medoid_indices_build = medoid_indices;
   arma::rowvec assignments(data.n_cols);
   size_t i = 0;
@@ -40,8 +38,8 @@ void km::KMedoids::fit_naive(const arma::mat& input_data) {
     i++;
   }
   medoid_indices_final = medoid_indices;
-  labels = assignments;
-  steps = i;
+  this->labels = assignments;
+  this->steps = i;
 }
 
 /**


### PR DESCRIPTION
I have fixed the following:

- Logic change: whenever there is a change in `algorithm` through `setter`, it is checked right after the `setter` so we don't need to do it in `fit` which is the original reason for the `checkAlgorithm()` to be there. 
- Add optional argument for `algorithm` in Python code. We can now change the algorithm like in the following example:
<img width="1015" alt="Screen Shot 2021-08-13 at 3 33 12 PM" src="https://user-images.githubusercontent.com/25496074/129409732-01c5f48e-d67c-4bd5-82aa-bc5c4bf68822.png">

- Make the global variables explicit by using `this->` pointer function. 