### PR TITLE
Create headers for banditpam.cpp and pam.cpp

### DIFF
--- a/headers/banditpam.hpp
+++ b/headers/banditpam.hpp
@@ -1,0 +1,116 @@
+#ifndef BANDITPAM_H_
+#define BANDITPAM_H_
+
+#include "kmedoids_algorithm.hpp"
+#include "log_helper.hpp"
+
+#include <carma>
+#include <armadillo>
+#include <vector>
+#include <fstream>
+#include <iostream>
+#include <chrono>
+#include <omp.h>
+
+/**
+ *  \brief Class implementation for BanditPAM algorithm. 
+ *
+ *  BanditPAM class. Consists of all necessary functions to implement 
+ *  BanditPAM algorithm. 
+ *  
+ */
+class BanditPAM : public km::KMedoids {
+public:
+    /*! \brief Runs BanditPAM algorithm.
+    * 
+    *  Run the BanditPAM algorithm to identify a dataset's medoids.
+    *
+    *  @param input_data Input data to cluster
+    */
+    void fit_bpam(const arma::mat& inputData);
+
+    /*! \brief Build step for BanditPAM
+    *
+    *  Runs build step for the BanditPAM algorithm. Draws batch sizes with replacement
+    *  from reference set, and uses the estimated reward of the potential medoid
+    *  solutions on the reference set to update the reward confidence intervals and
+    *  accordingly narrow the solution set.
+    *
+    *  @param data Transposed input data to find the medoids of
+    *  @param medoid_indices Uninitialized array of medoids that is modified in place
+    *  as medoids are identified
+    *  @param medoids Matrix of possible medoids that is updated as the bandit
+    *  learns which datapoints will be unlikely to be good candidates
+    */
+    void build(const arma::mat& data, arma::rowvec& medoidIndices, arma::mat& medoids);
+
+    /*! \brief Estimates the mean reward for each arm in build step
+    *
+    *  Estimates the mean reward (or loss) for each arm in the identified targets
+    *  in the build step and returns a list of the estimated reward.
+    *
+    *  @param data Transposed input data to find the medoids of
+    *  @param target Set of target datapoints to be estimated
+    *  @param batch_size Number of datapoints sampled for updating confidence
+    *  intervals
+    *  @param best_distances Array of best distances from each point to previous set
+    *  of medoids
+    *  @param use_absolute Determines whether the absolute cost is added to the total
+    */
+    arma::rowvec build_target(
+        const arma::mat& data,
+        arma::uvec& target,
+        size_t batch_size,
+        arma::rowvec& best_distances,
+        bool use_absolute
+    );
+
+    /*! \brief Swap step for BanditPAM
+    *
+    *  Runs Swap step for the BanditPAM algorithm. Draws batch sizes with replacement
+    *  from reference set, and uses the estimated reward of the potential medoid
+    *  solutions on the reference set to update the reward confidence intervals and
+    *  accordingly narrow the solution set.
+    *
+    *  @param data Transposed input data to find the medoids of
+    *  @param medoid_indices Array of medoid indices created from the build step
+    *  that is modified in place as better medoids are identified
+    *  @param medoids Matrix of possible medoids that is updated as the bandit
+    *  learns which datapoints will be unlikely to be good candidates
+    *  @param assignments Uninitialized array of indices corresponding to each
+    *  datapoint assigned the index of the medoid it is closest to
+    */
+    void swap(
+        const arma::mat& data,
+        arma::rowvec& medoidIndices,
+        arma::mat& medoids,
+        arma::rowvec& assignments
+    );
+
+    /*! \brief Estimates the mean reward for each arm in swap step
+    *
+    *  Estimates the mean reward (or loss) for each arm in the identified targets
+    *  in the swap step and returns a list of the estimated reward.
+    *
+    *  @param data Transposed input data to find the medoids of
+    *  @param sigma Dispersion paramater for each datapoint
+    *  @param targets Set of target datapoints to be estimated
+    *  @param batch_size Number of datapoints sampled for updating confidence
+    *  intervals
+    *  @param best_distances Array of best distances from each point to previous set
+    *  of medoids
+    *  @param second_best_distances Array of second smallest distances from each
+    *  point to previous set of medoids
+    *  @param assignments Assignments of datapoints to their closest medoid
+    */
+    arma::vec swap_target(
+        const arma::mat& data,
+        arma::rowvec& medoidIndices,
+        arma::uvec& targets,
+        size_t batch_size,
+        arma::rowvec& best_distances,
+        arma::rowvec& second_best_distances,
+        arma::rowvec& assignments
+    );
+};
+#endif // BANDITPAM_H_

--- a/headers/fastpam1.hpp
+++ b/headers/fastpam1.hpp
@@ -57,5 +57,4 @@ public:
     */
     void swap_fastpam1(const arma::mat& data, arma::rowvec& medoid_indices, arma::rowvec& assignments);
 };
-
 #endif // FASTPAM1_H_

--- a/headers/kmedoids_algorithm.hpp
+++ b/headers/kmedoids_algorithm.hpp
@@ -92,21 +92,6 @@ namespace km {
 
     protected:
       // The functions below are PAM's constituent functions
-
-      void fit_bpam(const arma::mat& inputData);
-
-      void fit_naive(const arma::mat& inputData); // pass by ref? (and above)
-
-      void build_naive(const arma::mat& data, arma::rowvec& medoidIndices);
-
-      void swap_naive(const arma::mat& data, arma::rowvec& medoidIndices, arma::rowvec& assignments);
-
-      void build(
-        const arma::mat& data,
-        arma::rowvec& medoidIndices,
-        arma::mat& medoids
-      );
-
       void build_sigma(
         const arma::mat& data,
         arma::rowvec& best_distances,
@@ -115,36 +100,11 @@ namespace km {
         bool use_absolute
       );
 
-      arma::rowvec build_target(
-        const arma::mat& data,
-        arma::uvec& target,
-        size_t batch_size,
-        arma::rowvec& best_distances,
-        bool use_absolute
-      );
-
-      void swap(
-        const arma::mat& data,
-        arma::rowvec& medoidIndices,
-        arma::mat& medoids,
-        arma::rowvec& assignments
-      );
-
       void calc_best_distances_swap(
         const arma::mat& data,
         arma::rowvec& medoidIndices,
         arma::rowvec& best_distances,
         arma::rowvec& second_distances,
-        arma::rowvec& assignments
-      );
-
-      arma::vec swap_target(
-        const arma::mat& data,
-        arma::rowvec& medoidIndices,
-        arma::uvec& targets,
-        size_t batch_size,
-        arma::rowvec& best_distances,
-        arma::rowvec& second_best_distances,
         arma::rowvec& assignments
       );
 

--- a/headers/pam.hpp
+++ b/headers/pam.hpp
@@ -1,0 +1,58 @@
+#ifndef PAM_H_
+#define PAM_H_
+
+#include "kmedoids_algorithm.hpp"
+#include "log_helper.hpp"
+
+#include <carma>
+#include <armadillo>
+#include <vector>
+#include <fstream>
+#include <iostream>
+#include <chrono>
+#include <omp.h>
+
+/**
+ *  \brief Class implementation for PAM algorithm. 
+ *
+ *  PAM class. Consists of all necessary functions to implement 
+ *  PAM algorithm. 
+ *  
+ */
+class PAM : public km::KMedoids {
+public:
+    /*! \brief Runs PAM algorithm.
+    * 
+    *  Run the PAM algorithm to identify a dataset's medoids.
+    *
+    *  @param input_data Input data to cluster
+    */
+    void fit_naive(const arma::mat& inputData);
+
+    /*! \brief Build step for the PAM algorithm
+    *
+    *  Runs build step for the PAM algorithm. Loops over all datapoint and
+    *  checks its distance from every other datapoint in the dataset, then checks if
+    *  the total cost is less than that of the medoid (if a medoid exists yet).
+    *
+    *  @param data Transposed input data to cluster
+    *  @param medoid_indices Uninitialized array of medoids that is modified in place
+    *  as medoids are identified
+    */
+    void build_naive(const arma::mat& data, arma::rowvec& medoidIndices);
+
+    /*! \brief Swap step for the PAM algorithm
+    * 
+    *  Runs build step for the PAM algorithm. Loops over all datapoint and
+    *  checks its distance from every other datapoint in the dataset, then checks if
+    *  the total cost is less than that of the medoid.
+    *
+    *  @param data Transposed input data to find the medoids of
+    *  @param medoid_indices Array of medoid indices created from the build step
+    *  that is modified in place as better medoids are identified
+    *  @param assignments Uninitialized array of indices corresponding to each
+    *  datapoint assigned the index of the medoid it is closest to
+    */
+    void swap_naive(const arma::mat& data, arma::rowvec& medoidIndices, arma::rowvec& assignments);
+};
+#endif // PAM_H_

--- a/src/banditpam.cpp
+++ b/src/banditpam.cpp
@@ -7,6 +7,7 @@
  */
 #include "kmedoids_algorithm.hpp"
 #include "log_helper.hpp"
+#include "banditpam.hpp"
 
 #include <carma>
 #include <armadillo>
@@ -20,19 +21,19 @@
  *
  * @param input_data Input data to find the medoids of
  */
-void km::KMedoids::fit_bpam(const arma::mat& input_data) {
+void BanditPAM::fit_bpam(const arma::mat& input_data) {
   data = input_data;
   data = arma::trans(data);
   arma::mat medoids_mat(data.n_rows, n_medoids);
   arma::rowvec medoid_indices(n_medoids);
   // runs build step
-  km::KMedoids::build(data, medoid_indices, medoids_mat);
+  BanditPAM::build(data, medoid_indices, medoids_mat);
   steps = 0;
 
   medoid_indices_build = medoid_indices;
   arma::rowvec assignments(data.n_cols);
   // runs swap step
-  km::KMedoids::swap(data, medoid_indices, medoids_mat, assignments);
+  BanditPAM::swap(data, medoid_indices, medoids_mat, assignments);
   medoid_indices_final = medoid_indices;
   labels = assignments;
 }
@@ -51,7 +52,7 @@ void km::KMedoids::fit_bpam(const arma::mat& input_data) {
  * @param medoids Matrix of possible medoids that is updated as the bandit
  * learns which datapoints will be unlikely to be good candidates
  */
-void km::KMedoids::build(
+void BanditPAM::build(
   const arma::mat& data,
   arma::rowvec& medoid_indices,
   arma::mat& medoids)
@@ -153,7 +154,7 @@ void km::KMedoids::build(
  * of medoids
  * @param use_absolute Determines whether the absolute cost is added to the total
  */
-arma::rowvec km::KMedoids::build_target(
+arma::rowvec BanditPAM::build_target(
   const arma::mat& data,
   arma::uvec& target,
   size_t batch_size,
@@ -201,7 +202,7 @@ arma::rowvec km::KMedoids::build_target(
  * @param assignments Uninitialized array of indices corresponding to each
  * datapoint assigned the index of the medoid it is closest to
  */
-void km::KMedoids::swap(
+void BanditPAM::swap(
   const arma::mat& data,
   arma::rowvec& medoid_indices,
   arma::mat& medoids,
@@ -335,7 +336,7 @@ void km::KMedoids::swap(
  * point to previous set of medoids
  * @param assignments Assignments of datapoints to their closest medoid
  */
-arma::vec km::KMedoids::swap_target(
+arma::vec BanditPAM::swap_target(
   const arma::mat& data,
   arma::rowvec& medoid_indices,
   arma::uvec& targets,

--- a/src/kmedoids_algorithm.cpp
+++ b/src/kmedoids_algorithm.cpp
@@ -8,6 +8,8 @@
 #include "kmedoids_algorithm.hpp"
 #include "log_helper.hpp"
 #include "fastpam1.hpp"
+#include "pam.hpp"
+#include "banditpam.hpp"
 
 #include <carma>
 #include <armadillo>
@@ -292,13 +294,12 @@ void km::KMedoids::setLogFilename(const std::string& new_lname) {
 void km::KMedoids::fit(const arma::mat& input_data, const std::string& loss) {
   km::KMedoids::setLossFn(loss);
   if (algorithm == "naive") {
-    (this->fit_naive)(input_data);
+    static_cast<PAM*>(this)->fit_naive(input_data);
   } else if (algorithm == "BanditPAM") {
-    (this->fit_bpam)(input_data);
+    static_cast<BanditPAM*>(this)->fit_bpam(input_data);
   } else if (algorithm == "FastPAM1") {
     static_cast<FastPAM1*>(this)->fit_fastpam1(input_data);
   }
-  
   if (verbosity > 0) {
       logHelper.init(logFilename);
       logHelper.writeProfile(medoid_indices_build, medoid_indices_final, steps,

--- a/src/kmedoids_pywrapper.cpp
+++ b/src/kmedoids_pywrapper.cpp
@@ -10,6 +10,8 @@
 #include "kmedoids_algorithm.hpp"
 #include "log_helper.hpp"
 #include "fastpam1.hpp"
+#include "pam.hpp"
+#include "banditpam.hpp"
 
 #include <carma>
 #include <armadillo>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,8 @@
 #include "kmedoids_algorithm.hpp"
 #include "log_helper.hpp"
 #include "fastpam1.hpp"
+#include "pam.hpp"
+#include "banditpam.hpp"
 
 #include <armadillo>
 #include <chrono>

--- a/src/pam.cpp
+++ b/src/pam.cpp
@@ -7,6 +7,7 @@
  */
 #include "kmedoids_algorithm.hpp"
 #include "log_helper.hpp"
+#include "pam.hpp"
 
 #include <carma>
 #include <armadillo>
@@ -16,16 +17,16 @@
 /**
  * \brief Runs naive PAM algorithm.
  *
- * Run the naive PAM algorithm to identify a dataset's medoids.
+ * Run the PAM algorithm to identify a dataset's medoids.
  *
  * @param input_data Input data to find the medoids of
  */
-void km::KMedoids::fit_naive(const arma::mat& input_data) {
+void PAM::fit_naive(const arma::mat& input_data) {
   data = input_data;
   data = arma::trans(data);
   arma::rowvec medoid_indices(n_medoids);
   // runs build step
-  km::KMedoids::build_naive(data, medoid_indices);
+  PAM::build_naive(data, medoid_indices);
   steps = 0;
 
   medoid_indices_build = medoid_indices;
@@ -35,7 +36,7 @@ void km::KMedoids::fit_naive(const arma::mat& input_data) {
   while (i < max_iter && medoidChange) {
     auto previous(medoid_indices);
     // runs swap step as necessary
-    km::KMedoids::swap_naive(data, medoid_indices, assignments);
+    PAM::swap_naive(data, medoid_indices, assignments);
     medoidChange = arma::any(medoid_indices != previous);
     i++;
   }
@@ -45,9 +46,9 @@ void km::KMedoids::fit_naive(const arma::mat& input_data) {
 }
 
 /**
- * \brief Build step for the naive algorithm
+ * \brief Build step for the PAM algorithm
  *
- * Runs build step for the naive PAM algorithm. Loops over all datapoint and
+ * Runs build step for the PAM algorithm. Loops over all datapoint and
  * checks its distance from every other datapoint in the dataset, then checks if
  * the total cost is less than that of the medoid (if a medoid exists yet).
  *
@@ -55,7 +56,7 @@ void km::KMedoids::fit_naive(const arma::mat& input_data) {
  * @param medoid_indices Uninitialized array of medoids that is modified in place
  * as medoids are identified
  */
-void km::KMedoids::build_naive(
+void PAM::build_naive(
   const arma::mat& data, 
   arma::rowvec& medoid_indices)
 { 
@@ -107,9 +108,9 @@ void km::KMedoids::build_naive(
 }
 
 /**
- * \brief Swap step for the naive algorithm
+ * \brief Swap step for the PAM algorithm
  *
- * Runs build step for the naive PAM algorithm. Loops over all datapoint and
+ * Runs build step for the PAM algorithm. Loops over all datapoint and
  * checks its distance from every other datapoint in the dataset, then checks if
  * the total cost is less than that of the medoid.
  *
@@ -119,7 +120,7 @@ void km::KMedoids::build_naive(
  * @param assignments Uninitialized array of indices corresponding to each
  * datapoint assigned the index of the medoid it is closest to
  */
-void km::KMedoids::swap_naive(
+void PAM::swap_naive(
   const arma::mat& data, 
   arma::rowvec& medoid_indices,
   arma::rowvec& assignments)
@@ -134,18 +135,18 @@ void km::KMedoids::swap_naive(
   arma::rowvec second_distances(N);
 
   // calculate quantities needed for swap, best_distances and sigma
-  calc_best_distances_swap(
+  km::KMedoids::calc_best_distances_swap(
     data, medoid_indices, best_distances, second_distances, assignments);
 
-  swap_sigma(data,
-              sigma,
-              batchSize,
-              best_distances,
-              second_distances,
-              assignments);
+  km::KMedoids::swap_sigma(data,
+                           sigma,
+                           batchSize,
+                           best_distances,
+                           second_distances,
+                           assignments);
   
   // write the sigma distribution to logfile
-  sigma_log(sigma);
+  km::KMedoids::sigma_log(sigma);
 
   // iterate across the current medoids
   for (size_t k = 0; k < n_medoids; k++) {


### PR DESCRIPTION
I have added headers `banditpam.hpp` and `pam.hpp` for `banditpam.cpp` and `pam.cpp` respectively. The format of the header follows from the `fastpam.hpp` header I have created in the previous PR #112. The updated code is tested on Python using MNIST-1k as the dataset, all algorithms give expected results. 