### PR TITLE
Updating readme_ex2.py to avoid segfault

### DIFF
--- a/scripts/readme_ex2.py
+++ b/scripts/readme_ex2.py
@@ -1,8 +1,8 @@
-from banditpam import KMedoids
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from sklearn.manifold import TSNE
+from banditpam import KMedoids
 
 # Load the 1000-point subset of MNIST and calculate its t-SNE embeddings for visualization:
 X = pd.read_csv("data/MNIST-1k.csv", sep=" ", header=None).to_numpy()


### PR DESCRIPTION
For some reason, the order of imports matters; likely because some import has a side effect