### PR TITLE
Hotfix: fixing installation on paperspace gradient

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# We need this for the sdist uploaded to PyPI to include the headers
+graft headers
+include docs/long_desc.rst

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.build_ext import build_ext
 import distutils.sysconfig
 import distutils.spawn
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 
 class get_pybind_include(object):
@@ -203,7 +203,7 @@ def setup_colab():
         in_colab = False
 
     if in_colab:
-        # TODO: Dangerous os.system() call.
+        # TODO: Remove dangerous os.system() calls
         # See https://stackoverflow.com/a/51329156
         repo_location = os.path.join("/", "content", "BanditPAM")
         os.system('git clone https://github.com/ThrunGroup/BanditPAM.git' +
@@ -211,6 +211,34 @@ def setup_colab():
         os.system(repo_location +
                   '/scripts/colab_files/colab_install_armadillo.sh')
         os.system('rm -rf ' + repo_location)
+
+
+def setup_paperspace_gradient():
+    # Unfortunately, Paperspace Gradient does not make it easy to tell
+    # whether you're inside a Gradient instance. For this reason, we
+    # determine whether python is running inside a Gradient instance
+    # in a hacky way: by creating a blank file and testing if it appears
+    # where it would be if we were running on Gradient.
+
+    # TODO: Remove dangerous os.system() calls
+    # See https://stackoverflow.com/a/51329156
+
+    in_paperspace_gradient = False
+    os.system('touch delete-me.txt')
+    if os.path.exists('/notebooks/delete-me.txt'):
+        in_paperspace_gradient = True
+    os.system('rm delete-me.txt')
+
+    if in_paperspace_gradient:
+        os.system('apt update')
+        os.system('apt install -y build-essential checkinstall \
+            libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev \
+            libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev')
+        os.system('DEBIAN_FRONTEND=noninteractive TZ=America/NewYork \
+            apt install -y tk-dev')
+        os.system('git clone \
+            https://gitlab.com/conradsnicta/armadillo-code.git')
+        os.system('cd armadillo-code && cmake . && make install')
 
 
 def install_check_ubuntu():
@@ -231,6 +259,8 @@ def install_check_ubuntu():
     ]
 
     setup_colab()
+
+    setup_paperspace_gradient()
 
     for dep in dependencies:
         check_linux_package_installation(dep)

--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,23 @@ def check_linux_package_installation(pkg_name: str):
         )
     return output.decode().strip()
 
+def install_ubuntu_pkgs():
+    # TODO: Remove dangerous os.system() calls
+    # See https://stackoverflow.com/a/51329156
+    os.system('apt update')
+    os.system('apt install -y \
+        build-essential \
+        checkinstall \
+        libreadline-gplv2-dev \
+        libncursesw5-dev \
+        libssl-dev \
+        libsqlite3-dev \
+        libgdbm-dev \
+        libc6-dev \
+        libbz2-dev \
+        libffi-dev \
+        zlib1g-dev'
+        )
 
 def setup_colab():
     # If we're in Google Colab, we need to manually copy over
@@ -205,8 +222,10 @@ def setup_colab():
     if in_colab:
         # TODO: Remove dangerous os.system() calls
         # See https://stackoverflow.com/a/51329156
+        install_ubuntu_pkgs()
         repo_location = os.path.join("/", "content", "BanditPAM")
-        os.system('git clone https://github.com/ThrunGroup/BanditPAM.git' +
+        # Note the space after the git URL to separate the source and target
+        os.system('git clone https://github.com/ThrunGroup/BanditPAM.git ' +
                   repo_location)
         os.system(repo_location +
                   '/scripts/colab_files/colab_install_armadillo.sh')
@@ -217,23 +236,15 @@ def setup_paperspace_gradient():
     # Unfortunately, Paperspace Gradient does not make it easy to tell
     # whether you're inside a Gradient instance. For this reason, we
     # determine whether python is running inside a Gradient instance
-    # in a hacky way: by creating a blank file and testing if it appears
-    # where it would be if we were running on Gradient.
+    # by checking for a /notebooks directory
 
     # TODO: Remove dangerous os.system() calls
     # See https://stackoverflow.com/a/51329156
 
-    in_paperspace_gradient = False
-    os.system('touch delete-me.txt')
-    if os.path.exists('/notebooks/delete-me.txt'):
-        in_paperspace_gradient = True
-    os.system('rm delete-me.txt')
+    in_paperspace_gradient = os.path.exists('/notebooks')
 
     if in_paperspace_gradient:
-        os.system('apt update')
-        os.system('apt install -y build-essential checkinstall \
-            libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev \
-            libgdbm-dev libc6-dev libbz2-dev libffi-dev zlib1g-dev')
+        install_ubuntu_pkgs()
         os.system('DEBIAN_FRONTEND=noninteractive TZ=America/NewYork \
             apt install -y tk-dev')
         os.system('git clone \


### PR DESCRIPTION
Contains a hotfix for #170 and some Google Colab bugs.

For Paperspace Gradient:
- allows users to install `banditpam==3.0.1` on Paperspace Gradient instances by installing the necessary dependencies and `armadillo 10.8` automatically in `setup.py`
- Builds a recent (`>=10.8`) armadillo from source

For Google Colab:
- Installs the necessary Ubuntu dependencies
- Fixes a missing space that was conjoining the repo name with the local installation path
- Replaces the `MANIFEST.in` so the `headers` are properly included in the source distribution

Note: On Google Colab, the installed `cmake` is only `3.12`, so we do NOT build `armadillo` from source as doing so would require building a newer version of `cmake`, which takes way too long. Instead, we keep the current workaround of building the updated `armadillo` libraries in this repo and then copying them into the correct places in Colab

Also contains version bump to 3.0.1.