### PR TITLE
BanditPAM `v3.0.2`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ src/main
 src/main.dSYM/
 tmp/
 var/
+dist/
+wheelhouse/

--- a/headers/algorithms/kmedoids_algorithm.hpp
+++ b/headers/algorithms/kmedoids_algorithm.hpp
@@ -29,7 +29,8 @@ class KMedoids {
     const std::string& algorithm = "BanditPAM",
     size_t maxIter = 1000,
     size_t buildConfidence = 1000,
-    size_t swapConfidence = 10000);
+    size_t swapConfidence = 10000,
+    size_t seed = 0);
 
   ~KMedoids();
 
@@ -149,6 +150,20 @@ class KMedoids {
    * @throws If attempting to set buildConfidence when not using BanditPAM
    */
   void setSwapConfidence(size_t newSwapConfidence);
+
+  /**
+   * @brief Sets the random seed for armadillo.
+   *
+   * @param newSeed The new seed value to use
+   */
+  void setSeed(size_t newSeed);
+
+  /**
+   * @brief Gets the value of the last supplied seed used by armadillo
+   *
+   * @param newSeed The new seed value to use
+   */
+  size_t getSeed() const;
 
   /**
    * @brief Sets the loss function to use during clustering.
@@ -364,6 +379,9 @@ class KMedoids {
 
   /// Number of points to sample per reference batch
   size_t batchSize = 100;
+
+  /// The random seed with which to perform the clustering
+  size_t seed = 0;
 };
 }  // namespace km
 #endif  // HEADERS_ALGORITHMS_KMEDOIDS_ALGORITHM_HPP_

--- a/headers/algorithms/kmedoids_algorithm.hpp
+++ b/headers/algorithms/kmedoids_algorithm.hpp
@@ -198,7 +198,8 @@ class KMedoids {
     const arma::urowvec* medoidIndices,
     arma::frowvec* bestDistances,
     arma::frowvec* secondBestDistances,
-    arma::urowvec* assignments);
+    arma::urowvec* assignments,
+    const bool swapPerformed = true);
 
   /**
    * @brief Calculate the average loss for the given choice of medoids. 
@@ -341,6 +342,9 @@ class KMedoids {
 
   /// Used for floatcomparisons, primarily number of "arms" remaining
   const float precision = 0.001;
+
+  /// Contains the average loss at the last step of the algorithm
+  float averageLoss;
 
   /// Number of points to sample per reference batch
   size_t batchSize = 100;

--- a/headers/algorithms/kmedoids_algorithm.hpp
+++ b/headers/algorithms/kmedoids_algorithm.hpp
@@ -201,12 +201,13 @@ class KMedoids {
     arma::urowvec* assignments);
 
   /**
-   * @brief Calculate the overall loss for the given choice of medoids. 
+   * @brief Calculate the average loss for the given choice of medoids. 
    * 
    * @param data Transposed data to cluster
    * @param medoidIndices Indices of the medoids in the dataset
    * 
-   * @returns The total (not average) loss
+   * @returns The average loss, i.e., the average distance from each point to its
+   * nearest medoid
    */
   float calcLoss(
     const arma::fmat& data,

--- a/headers/algorithms/kmedoids_algorithm.hpp
+++ b/headers/algorithms/kmedoids_algorithm.hpp
@@ -159,6 +159,22 @@ class KMedoids {
    */
   void setLossFn(std::string loss);
 
+  /**
+   * @brief Gets the loss function currently used by the KMedoids object
+   *
+   * @returns Loss function currently being recognized
+   */
+  std::string getLossFn() const;
+
+  /**
+   * @brief Get the average loss from the prior clustering
+   *
+   * @returns The average clustering loss from the prior clusteringq
+   *
+   * @throws If no clustering has been run yet
+   */
+  float getAverageLoss() const;
+
   /// The cache will be of size cacheMultiplier*nlogn
   size_t cacheMultiplier = 1000;
 

--- a/headers/python_bindings/kmedoids_pywrapper.hpp
+++ b/headers/python_bindings/kmedoids_pywrapper.hpp
@@ -63,33 +63,46 @@ class KMedoidsWrapper : public km::KMedoids {
    * KMedoids::fit
    */
   int getStepsPython();
+
+  /**
+   * @brief Returns the average clustering loss
+   *
+   * The average loss, i.e., the average distance from each point to its
+   * nearest medoid
+   */
+  float getLossPython();
 };
 
 // TODO(@motiwari): Encapsulate these
 
 /**
- * @brief Python function to bind to the C++ function KMedoids::fit
+ * @brief Binding for the C++ function KMedoids::fit
  */
 void fit_python(pybind11::class_<km::KMedoidsWrapper> *);
 
 /**
- * @brief Python function to bind to the C++ function KMedoids::getMedoidsBuild()
+ * @brief Binding for the C++ function KMedoids::getMedoidsBuild()
  */
 void build_medoids_python(pybind11::class_<km::KMedoidsWrapper> *);
 
 /**
- * @brief Python function to bind to the C++ function KMedoids::getMedoidsFinal()
+ * @brief Binding for the C++ function KMedoids::getMedoidsFinal()
  */
 void medoids_python(pybind11::class_<km::KMedoidsWrapper> *);
 
 /**
- * @brief Python function to bind to the C++ function KMedoids::getLabels()
+ * @brief Binding for the C++ function KMedoids::getLabels()
  */
 void labels_python(pybind11::class_<km::KMedoidsWrapper> *);
 
 /**
- * @brief Python function to bind to the C++ function KMedoids::getSteps()
+ * @brief Binding for the C++ function KMedoids::getSteps()
  */
 void steps_python(pybind11::class_<km::KMedoidsWrapper> *);
+
+/**
+ * @brief Binding for the C++ function KMedoids::calcLoss()
+ */
+void loss_python(pybind11::class_<km::KMedoidsWrapper> *);
 }  // namespace km
 #endif  // HEADERS_PYTHON_BINDINGS_KMEDOIDS_PYWRAPPER_HPP_

--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,7 @@ def install_ubuntu_pkgs():
     )  # noqa: E124
 
 
-def setup_colab(delete_source=True):
+def setup_colab(delete_source=False):
     # If we're in Google Colab, we need to manually copy over
     # the prebuilt armadillo libraries
     # NOTE: This only works for Colab instances with Ubuntu 18.04 Runtimes!
@@ -225,6 +225,9 @@ def setup_colab(delete_source=True):
         # TODO: Remove dangerous os.system() calls
         # See https://stackoverflow.com/a/51329156
         install_ubuntu_pkgs()
+
+        # TODO(@motiwari): Make this a randomly-named directory 
+        # and set delete_source=True always
         repo_location = os.path.join("/", "content", "BanditPAM")
         # Note the space after the git URL to separate the source and target
         os.system('git clone https://github.com/ThrunGroup/BanditPAM.git ' +

--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,7 @@ def check_linux_package_installation(pkg_name: str):
         )
     return output.decode().strip()
 
+
 def install_ubuntu_pkgs():
     # TODO: Remove dangerous os.system() calls
     # See https://stackoverflow.com/a/51329156
@@ -207,7 +208,8 @@ def install_ubuntu_pkgs():
         libbz2-dev \
         libffi-dev \
         zlib1g-dev'
-        )
+    )  # noqa: E124
+
 
 def setup_colab():
     # If we're in Google Colab, we need to manually copy over

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.build_ext import build_ext
 import distutils.sysconfig
 import distutils.spawn
 
-__version__ = "3.0.4"
+__version__ = "3.0.4a"
 
 
 class get_pybind_include(object):
@@ -231,7 +231,7 @@ def setup_colab():
                   repo_location)
         os.system(repo_location +
                   '/scripts/colab_files/colab_install_armadillo.sh')
-        os.system('rm -rf ' + repo_location)
+        # os.system('rm -rf ' + repo_location)
 
 
 def setup_paperspace_gradient():

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.build_ext import build_ext
 import distutils.sysconfig
 import distutils.spawn
 
-__version__ = "3.0.4a0"
+__version__ = "3.0.2"
 
 
 class get_pybind_include(object):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.build_ext import build_ext
 import distutils.sysconfig
 import distutils.spawn
 
-__version__ = "3.0.1"
+__version__ = "3.0.3"
 
 
 class get_pybind_include(object):

--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,7 @@ def install_ubuntu_pkgs():
     )  # noqa: E124
 
 
-def setup_colab():
+def setup_colab(delete_source=True):
     # If we're in Google Colab, we need to manually copy over
     # the prebuilt armadillo libraries
     # NOTE: This only works for Colab instances with Ubuntu 18.04 Runtimes!
@@ -231,7 +231,8 @@ def setup_colab():
                   repo_location)
         os.system(repo_location +
                   '/scripts/colab_files/colab_install_armadillo.sh')
-        # os.system('rm -rf ' + repo_location)
+        if delete_source:
+            os.system('rm -rf ' + repo_location)
 
 
 def setup_paperspace_gradient():
@@ -271,7 +272,7 @@ def install_check_ubuntu():
         "zlib1g-dev",
     ]
 
-    setup_colab()
+    setup_colab(delete_source=False)
 
     setup_paperspace_gradient()
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.build_ext import build_ext
 import distutils.sysconfig
 import distutils.spawn
 
-__version__ = "3.0.4a"
+__version__ = "3.0.4a0"
 
 
 class get_pybind_include(object):
@@ -226,7 +226,7 @@ def setup_colab(delete_source=False):
         # See https://stackoverflow.com/a/51329156
         install_ubuntu_pkgs()
 
-        # TODO(@motiwari): Make this a randomly-named directory 
+        # TODO(@motiwari): Make this a randomly-named directory
         # and set delete_source=True always
         repo_location = os.path.join("/", "content", "BanditPAM")
         # Note the space after the git URL to separate the source and target

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.build_ext import build_ext
 import distutils.sysconfig
 import distutils.spawn
 
-__version__ = "3.0.3"
+__version__ = "3.0.4"
 
 
 class get_pybind_include(object):
@@ -401,6 +401,7 @@ def main():
                              "build_medoids_python.cpp"),
                 os.path.join("src", "python_bindings", "labels_python.cpp"),
                 os.path.join("src", "python_bindings", "steps_python.cpp"),
+                os.path.join("src", "python_bindings", "loss_python.cpp"),
             ],
             include_dirs=include_dirs,
             library_dirs=[os.path.join("/", "usr", "local", "lib")],

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -359,7 +359,6 @@ void BanditPAM::swap(
 
   arma::frowvec bestDistances(N);
   arma::frowvec secondBestDistances(N);
-  size_t iter = 0;
   bool swapPerformed = true;
   arma::umat candidates(nMedoids, N, arma::fill::ones);
   arma::umat exactMask(nMedoids, N, arma::fill::zeros);
@@ -378,8 +377,8 @@ void BanditPAM::swap(
     swapPerformed);
 
   // continue making swaps while loss is decreasing
-  while (swapPerformed && iter < maxIter) {
-    iter++;
+  while (swapPerformed && steps < maxIter) {
+    steps++;
     permutationIdx = 0;
 
     sigma = swapSigma(
@@ -445,7 +444,7 @@ void BanditPAM::swap(
       candidates = (lcbs < ucbs.min()) && (exactMask == 0);
       targets = arma::find(candidates);
     }
-    
+
     // Perform the medoid switch
     arma::uword newMedoid = lcbs.index_min();
     // extract old and new medoids of swap

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -2,8 +2,7 @@
  * @file banditpam.cpp
  * @date 2021-07-25
  *
- * This file contains the primary C++ implementation of the BanditPAM code.
- *
+ * Contains the primary C++ implementation of the BanditPAM code.
  */
 
 #include "banditpam.hpp"

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -445,25 +445,26 @@ void BanditPAM::swap(
       candidates = (lcbs < ucbs.min()) && (exactMask == 0);
       targets = arma::find(candidates);
     }
-    // now switch medoids
+    
+    // Perform the medoid switch
     arma::uword newMedoid = lcbs.index_min();
-    // extract medoid of swap
+    // extract old and new medoids of swap
     size_t k = newMedoid % medoids->n_cols;
-
-    // extract data point of swap
     size_t n = newMedoid / medoids->n_cols;
     swapPerformed = (*medoidIndices)(k) != n;
     steps++;
 
-    (*medoidIndices)(k) = n;
-    medoids->col(k) = data.col((*medoidIndices)(k));
-    calcBestDistancesSwap(
-      data,
-      medoidIndices,
-      &bestDistances,
-      &secondBestDistances,
-      assignments,
-      swapPerformed);
+    if (swapPerformed) {
+      (*medoidIndices)(k) = n;
+      medoids->col(k) = data.col((*medoidIndices)(k));
+      calcBestDistancesSwap(
+        data,
+        medoidIndices,
+        &bestDistances,
+        &secondBestDistances,
+        assignments,
+        swapPerformed);
+    }
   }
 }
 }  // namespace km

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -455,7 +455,7 @@ void BanditPAM::swap(
 
     if (swapPerformed) {
       (*medoidIndices)(k) = n;
-      medoids->col(k) = data.col((*medoidIndices)(k)); 
+      medoids->col(k) = data.col((*medoidIndices)(k));
     }
     calcBestDistancesSwap(
         data,

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -455,15 +455,15 @@ void BanditPAM::swap(
 
     if (swapPerformed) {
       (*medoidIndices)(k) = n;
-      medoids->col(k) = data.col((*medoidIndices)(k));
-      calcBestDistancesSwap(
+      medoids->col(k) = data.col((*medoidIndices)(k)); 
+    }
+    calcBestDistancesSwap(
         data,
         medoidIndices,
         &bestDistances,
         &secondBestDistances,
         assignments,
         swapPerformed);
-    }
   }
 }
 }  // namespace km

--- a/src/algorithms/banditpam.cpp
+++ b/src/algorithms/banditpam.cpp
@@ -13,8 +13,7 @@
 
 namespace km {
 void BanditPAM::fitBanditPAM(const arma::fmat& inputData) {
-  data = inputData;
-  data = arma::trans(data);
+  data = arma::trans(inputData);
 
   if (this->useCacheP) {
     size_t n = data.n_cols;
@@ -23,7 +22,7 @@ void BanditPAM::fitBanditPAM(const arma::fmat& inputData) {
 
     #pragma omp parallel for
     for (size_t idx = 0; idx < m*n; idx++) {
-      cache[idx] = -1;
+      cache[idx] = -1;  // TODO(@motiwari): need better value here
     }
 
     permutation = arma::randperm(n);

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -2,12 +2,13 @@
  * @file fastpam1.cpp
  * @date 2021-08-03
  *
- * Contains the primary C++ implementation of the FastPAM1 code follows
+ * This file contains the primary C++ implementation of the FastPAM1 code follows
  * from the paper: Erich Schubert and Peter J. Rousseeuw: Faster k-Medoids Clustering:
  * Improving the PAM, CLARA, and CLARANS Algorithms. (https://arxiv.org/pdf/1810.05691.pdf).
  * The original PAM papers are:
  * 1) Leonard Kaufman and Peter J. Rousseeuw: Clustering by means of medoids.
  * 2) Leonard Kaufman and Peter J. Rousseeuw: Partitioning around medoids (program pam).
+ *
  */
 
 #include "fastpam1.hpp"
@@ -46,18 +47,16 @@ void FastPAM1::buildFastPAM1(
   arma::frowvec bestDistances(N);
   bestDistances.fill(std::numeric_limits<float>::infinity());
   arma::frowvec sigma(N);
-  float total = 0;
-  float minDistance = std::numeric_limits<float>::infinity();
-  int best = 0;
-  float cost = 0;
-  // TODO (@motiwari): pragma omp parallel for?
   for (size_t k = 0; k < nMedoids; k++) {
-    minDistance = std::numeric_limits<float>::infinity();
-    best = 0;
+    float minDistance = std::numeric_limits<float>::infinity();
+    int best = 0;
+    // fixes a base datapoint
     for (size_t i = 0; i < data.n_cols; i++) {
-      total = 0;
+      float total = 0;
       for (size_t j = 0; j < data.n_cols; j++) {
-        cost = (this->*lossFn)(data, i, j);
+        // computes distance between base and all other points
+        float cost = (this->*lossFn)(data, i, j);
+        // compares this with the cached best distance
         if (bestDistances(j) < cost) {
           cost = bestDistances(j);
         }
@@ -71,10 +70,8 @@ void FastPAM1::buildFastPAM1(
     (*medoidIndices)(k) = best;
 
     // update the medoid assignment and best_distance for this datapoint
-    float cost = 0;
-    #pragma omp parallel for
     for (size_t l = 0; l < N; l++) {
-      cost = (this->*lossFn)(data, l, (*medoidIndices)(k));
+      float cost = (this->*lossFn)(data, l, (*medoidIndices)(k));
       if (cost < bestDistances(l)) {
         bestDistances(l) = cost;
       }
@@ -90,16 +87,12 @@ void FastPAM1::swapFastPAM1(
   float bestChange = 0;
   float minDistance = std::numeric_limits<float>::infinity();
   size_t best = 0;
-  size_t medoidToSwap = 0;
+  size_t medoid_to_swap = 0;
   size_t N = data.n_cols;
   arma::fmat sigma(nMedoids, N, arma::fill::zeros);
   arma::frowvec bestDistances(N);
   arma::frowvec secondBestDistances(N);
   arma::frowvec deltaTD(nMedoids, arma::fill::zeros);
-  bool swapPerformed = true;
-  float di = 0;
-  float dij = 0;
-  size_t iter = 0;
 
   // calculate quantities needed for swap, bestDistances and sigma
   KMedoids::calcBestDistancesSwap(
@@ -107,17 +100,15 @@ void FastPAM1::swapFastPAM1(
     medoidIndices,
     &bestDistances,
     &secondBestDistances,
-    assignments,
-    swapPerformed);
+    assignments);
 
-  while (swapPerformed && iter < maxIter) {
-    iter++;
-    for (size_t i = 0; i < data.n_cols; i++) {
-      di = bestDistances(i);
-      // compute loss change for making i a medoid
-      deltaTD.fill(-di);
-      for (size_t j = 0; j < data.n_cols; j++) {
-        dij = (this->*lossFn)(data, i, j);
+  for (size_t i = 0; i < data.n_cols; i++) {
+    float di = bestDistances(i);
+    // compute loss change for making i a medoid
+    deltaTD.fill(-di);
+    for (size_t j = 0; j < data.n_cols; j++) {
+      if (j != i) {
+        float dij = (this->*lossFn)(data, i, j);
         // update loss change for the current
         if (dij < secondBestDistances(j)) {
           deltaTD.at((*assignments)(j)) += (dij - bestDistances(j));
@@ -133,31 +124,23 @@ void FastPAM1::swapFastPAM1(
           deltaTD.at((*assignments)(j)) -= (dij -  bestDistances(j));
         }
       }
-      
-      // choose the best medoid-to-swap
-      arma::uword newMedoid = deltaTD.index_min();
-      // if the loss change is better than the best loss change,
-      // update the best index identified so far
-      if (deltaTD.min() < bestChange) {
-        bestChange = deltaTD.min();
-        best = i;
-        medoidToSwap = newMedoid;
-      }
     }
-    // update the loss and medoid if the loss is improved
-    if (bestChange < -precision) {
-      (*medoidIndices)(medoidToSwap) = best;
-    } else {
-      swapPerformed = false;
+    // choose the best medoid-to-swap
+    arma::uword minMedoid = deltaTD.index_min();
+    // if the loss change is better than the best loss change,
+    // update the best index identified so far
+    if (deltaTD.min() < bestChange) {
+      bestChange = deltaTD.min();
+      best = i;
+      medoid_to_swap = minMedoid;
     }
-
-    calcBestDistancesSwap(
-      data,
-      medoidIndices,
-      &bestDistances,
-      &secondBestDistances,
-      assignments,
-      swapPerformed);
+  }
+  // update the loss and medoid if the loss is improved
+  if (bestChange < 0) {
+    minDistance = arma::sum(bestDistances) + bestChange;
+    (*medoidIndices)(medoid_to_swap) = best;
+  } else {
+    minDistance = arma::sum(bestDistances);
   }
 }
 }  // namespace km

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -62,7 +62,7 @@ void FastPAM1::buildFastPAM1(
       // TODO(@motiwari): pragma omp parallel for?
       for (size_t j = 0; j < data.n_cols; j++) {
         // computes distance between base and all other points
-        cost = (*lossFn)(data, i, j);
+        cost = (this->*lossFn)(data, i, j);
         // compares this with the cached best distance
         if (bestDistances(j) < cost) {
           cost = bestDistances(j);
@@ -79,7 +79,7 @@ void FastPAM1::buildFastPAM1(
     // update the medoid assignment and best_distance for this datapoint
     // TODO(@motiwari): pragma omp parallel for?
     for (size_t l = 0; l < N; l++) {
-      cost = (*lossFn)(data, l, (*medoidIndices)(k));
+      cost = (this->*lossFn)(data, l, (*medoidIndices)(k));
       if (cost < bestDistances(l)) {
         bestDistances(l) = cost;
       }
@@ -129,7 +129,7 @@ void FastPAM1::swapFastPAM1(
       // TODO(@motiwari): pragma omp parallel for?
       for (size_t j = 0; j < data.n_cols; j++) {
         if (j != i) {
-          dij = (*lossFn)(data, i, j);
+          dij = (this->*lossFn)(data, i, j);
           if (dij < bestDistances(j)) {
             // Case 1: point i becomes the closest medoid for point j,
             // regardless of which medoid j was previously assigned to. deltaTD

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -50,7 +50,7 @@ void FastPAM1::buildFastPAM1(
   int best = 0;
   float total = 0;
   float cost = 0;
-  
+
   // TODO(@motiwari): pragma omp parallel for?
   for (size_t k = 0; k < nMedoids; k++) {
     minDistance = std::numeric_limits<float>::infinity();
@@ -94,9 +94,10 @@ void FastPAM1::swapFastPAM1(
 ) {
   float bestChange = 0;
   float minDistance = std::numeric_limits<float>::infinity();
-  size_t best = 0;
+  size_t swapIn = 0;
   size_t medoidToSwap = 0;
   size_t N = data.n_cols;
+  size_t iter = 0;
   bool swapPerformed = true;
   arma::fmat sigma(nMedoids, N, arma::fill::zeros);
   arma::frowvec bestDistances(N);
@@ -115,55 +116,61 @@ void FastPAM1::swapFastPAM1(
   float di = 0;
   float dij = 0;
 
-  // TODO(@motiwari): pragma omp parallel for?
-  for (size_t i = 0; i < data.n_cols; i++) {
-    di = bestDistances(i);
-    
-    // Consider making point i a medoid.
-    // The total loss then contains at least one term, -di,
-    // because the loss contribution for point i is reduced to 0
-    deltaTD.fill(-di);
+  while (swapPerformed && iter < maxIter) {
+    iter++;
     // TODO(@motiwari): pragma omp parallel for?
-    for (size_t j = 0; j < data.n_cols; j++) {
-      if (j != i) {
-        dij = KMedoids::cachedLoss(data, i, j);
-        if (dij < bestDistances(j)) {
-          // Case 1: point i becomes the closest medoid for point j,
-          // regardless of which medoid j was previously assigned to. deltaTD
-          // will be negative across ALL possible medoid indices m
-          deltaTD += (dij -  bestDistances(j));
-        } else if (dij < secondBestDistances(j)) {
-          // Case 2: i. If point i is closer than the second best
-          // medoid but further than the best medoid (enforced by failing
-          // the condition for the above if condition), point i will 
-          // become the closest medoid only when we remove its associated 
-          // medoid and add point i
-          deltaTD.at((*assignments)(j)) += (dij - bestDistances(j));
-        }  else {
-          // Case 3: dij > secondBestDistances(j). Then the loss for point j
-          // will not change for any medoid swapped out except for its
-          // assignment, in which case it moves to its second nearest medoid
-          deltaTD.at((*assignments)(j)) +=
-            (secondBestDistances(j) - bestDistances(j));
-        } 
+    for (size_t i = 0; i < data.n_cols; i++) {
+      di = bestDistances(i);
+
+      // Consider making point i a medoid.
+      // The total loss then contains at least one term, -di,
+      // because the loss contribution for point i is reduced to 0
+      deltaTD.fill(-di);
+      // TODO(@motiwari): pragma omp parallel for?
+      for (size_t j = 0; j < data.n_cols; j++) {
+        if (j != i) {
+          dij = KMedoids::cachedLoss(data, i, j);
+          if (dij < bestDistances(j)) {
+            // Case 1: point i becomes the closest medoid for point j,
+            // regardless of which medoid j was previously assigned to. deltaTD
+            // will be negative across ALL possible medoid indices m
+            deltaTD += (dij -  bestDistances(j));
+          } else if (dij < secondBestDistances(j)) {
+            // Case 2: i. If point i is closer than the second best
+            // medoid but further than the best medoid (enforced by failing
+            // the condition for the above if condition), point i will
+            // become the closest medoid only when we remove its associated
+            // medoid and add point i
+            deltaTD.at((*assignments)(j)) += (dij - bestDistances(j));
+          }  else {
+            // Case 3: dij > secondBestDistances(j). Then the loss for point j
+            // will not change for any medoid swapped out except for its
+            // assignment, in which case it moves to its second nearest medoid
+            deltaTD.at((*assignments)(j)) +=
+              (secondBestDistances(j) - bestDistances(j));
+          }
+        }
+      }
+
+      // Determine the best medoid to swap out
+      arma::uword swapOut = deltaTD.index_min();
+      // If the loss change is better than the best loss change so far,
+      // Update our running best statistics
+      if (deltaTD.min() < bestChange) {
+        bestChange = deltaTD.min();
+        swapIn = i;
+        medoidToSwap = swapOut;
       }
     }
-    // choose the best medoid-to-swap
-    arma::uword minMedoid = deltaTD.index_min();
-    // if the loss change is better than the best loss change,
-    // update the best index identified so far
-    if (deltaTD.min() < bestChange) {
-      bestChange = deltaTD.min();
-      best = i;
-      medoidToSwap = minMedoid;
+
+    // Update the loss and perform the swap if the loss would be improved
+    if (bestChange < 0) {
+      minDistance = arma::sum(bestDistances) + bestChange;
+      (*medoidIndices)(medoidToSwap) = swapIn;
+    } else {
+      minDistance = arma::sum(bestDistances);
+      swapPerformed = false;
     }
-  }
-  // update the loss and medoid if the loss is improved
-  if (bestChange < 0) {
-    minDistance = arma::sum(bestDistances) + bestChange;
-    (*medoidIndices)(medoidToSwap) = best;
-  } else {
-    minDistance = arma::sum(bestDistances);
   }
 }
 }  // namespace km

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -2,13 +2,12 @@
  * @file fastpam1.cpp
  * @date 2021-08-03
  *
- * This file contains the primary C++ implementation of the FastPAM1 code follows
+ * Contains the primary C++ implementation of the FastPAM1 code follows
  * from the paper: Erich Schubert and Peter J. Rousseeuw: Faster k-Medoids Clustering:
  * Improving the PAM, CLARA, and CLARANS Algorithms. (https://arxiv.org/pdf/1810.05691.pdf).
  * The original PAM papers are:
  * 1) Leonard Kaufman and Peter J. Rousseeuw: Clustering by means of medoids.
  * 2) Leonard Kaufman and Peter J. Rousseeuw: Partitioning around medoids (program pam).
- *
  */
 
 #include "fastpam1.hpp"

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -24,17 +24,11 @@ void FastPAM1::fitFastPAM1(const arma::fmat& inputData) {
   steps = 0;
   medoidIndicesBuild = medoidIndices;
   arma::urowvec assignments(data.n_cols);
-  size_t iter = 0;
-  bool medoidChange = true;
-  while (iter < maxIter && medoidChange) {
-    auto previous{medoidIndices};
-    FastPAM1::swapFastPAM1(data, &medoidIndices, &assignments);
-    medoidChange = arma::any(medoidIndices != previous);
-    iter++;
-  }
+
+  auto previous{medoidIndices};
+  FastPAM1::swapFastPAM1(data, &medoidIndices, &assignments);  
   medoidIndicesFinal = medoidIndices;
   labels = assignments;
-  steps = iter;
 }
 
 void FastPAM1::buildFastPAM1(
@@ -97,7 +91,6 @@ void FastPAM1::swapFastPAM1(
   size_t swapIn = 0;
   size_t medoidToSwap = 0;
   size_t N = data.n_cols;
-  size_t iter = 0;
   bool swapPerformed = true;
   arma::fmat sigma(nMedoids, N, arma::fill::zeros);
   arma::frowvec bestDistances(N);
@@ -116,8 +109,8 @@ void FastPAM1::swapFastPAM1(
   float di = 0;
   float dij = 0;
 
-  while (swapPerformed && iter < maxIter) {
-    iter++;
+  while (swapPerformed && steps < maxIter) {
+    steps++;
     // TODO(@motiwari): pragma omp parallel for?
     for (size_t i = 0; i < data.n_cols; i++) {
       di = bestDistances(i);

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -99,6 +99,7 @@ void FastPAM1::swapFastPAM1(
   bool swapPerformed = true;
   float di = 0;
   float dij = 0;
+  size_t iter = 0;
 
   // calculate quantities needed for swap, bestDistances and sigma
   KMedoids::calcBestDistancesSwap(

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -2,13 +2,12 @@
  * @file fastpam1.cpp
  * @date 2021-08-03
  *
- * This file contains the primary C++ implementation of the FastPAM1 code follows
+ * Contains the primary C++ implementation of the FastPAM1 code
  * from the paper: Erich Schubert and Peter J. Rousseeuw: Faster k-Medoids Clustering:
  * Improving the PAM, CLARA, and CLARANS Algorithms. (https://arxiv.org/pdf/1810.05691.pdf).
  * The original PAM papers are:
  * 1) Leonard Kaufman and Peter J. Rousseeuw: Clustering by means of medoids.
  * 2) Leonard Kaufman and Peter J. Rousseeuw: Partitioning around medoids (program pam).
- *
  */
 
 #include "fastpam1.hpp"
@@ -47,15 +46,20 @@ void FastPAM1::buildFastPAM1(
   arma::frowvec bestDistances(N);
   bestDistances.fill(std::numeric_limits<float>::infinity());
   arma::frowvec sigma(N);
+  float minDistance = std::numeric_limits<float>::infinity();
+  int best = 0;
+  float total = 0;
+  float cost = 0;
+  // TODO (@motiwari): pragma omp parallel for?
   for (size_t k = 0; k < nMedoids; k++) {
-    float minDistance = std::numeric_limits<float>::infinity();
-    int best = 0;
+    minDistance = std::numeric_limits<float>::infinity();
+    best = 0;
     // fixes a base datapoint
     for (size_t i = 0; i < data.n_cols; i++) {
-      float total = 0;
+      total = 0;
       for (size_t j = 0; j < data.n_cols; j++) {
         // computes distance between base and all other points
-        float cost = (this->*lossFn)(data, i, j);
+        cost = (this->*lossFn)(data, i, j);
         // compares this with the cached best distance
         if (bestDistances(j) < cost) {
           cost = bestDistances(j);
@@ -71,13 +75,17 @@ void FastPAM1::buildFastPAM1(
 
     // update the medoid assignment and best_distance for this datapoint
     for (size_t l = 0; l < N; l++) {
-      float cost = (this->*lossFn)(data, l, (*medoidIndices)(k));
+      cost = (this->*lossFn)(data, l, (*medoidIndices)(k));
       if (cost < bestDistances(l)) {
         bestDistances(l) = cost;
       }
     }
   }
 }
+
+// TODO: Used cachedLoss everywhere
+// TODO: Add comment about pragma omp parallel for
+// 
 
 void FastPAM1::swapFastPAM1(
   const arma::fmat& data,
@@ -87,7 +95,7 @@ void FastPAM1::swapFastPAM1(
   float bestChange = 0;
   float minDistance = std::numeric_limits<float>::infinity();
   size_t best = 0;
-  size_t medoid_to_swap = 0;
+  size_t medoidToSwap = 0;
   size_t N = data.n_cols;
   arma::fmat sigma(nMedoids, N, arma::fill::zeros);
   arma::frowvec bestDistances(N);
@@ -102,13 +110,16 @@ void FastPAM1::swapFastPAM1(
     &secondBestDistances,
     assignments);
 
+  float di = 0;
+  float dij = 0;
+
   for (size_t i = 0; i < data.n_cols; i++) {
-    float di = bestDistances(i);
+    di = bestDistances(i);
     // compute loss change for making i a medoid
     deltaTD.fill(-di);
     for (size_t j = 0; j < data.n_cols; j++) {
       if (j != i) {
-        float dij = (this->*lossFn)(data, i, j);
+        dij = (this->*lossFn)(data, i, j);
         // update loss change for the current
         if (dij < secondBestDistances(j)) {
           deltaTD.at((*assignments)(j)) += (dij - bestDistances(j));
@@ -132,13 +143,13 @@ void FastPAM1::swapFastPAM1(
     if (deltaTD.min() < bestChange) {
       bestChange = deltaTD.min();
       best = i;
-      medoid_to_swap = minMedoid;
+      medoidToSwap = minMedoid;
     }
   }
   // update the loss and medoid if the loss is improved
   if (bestChange < 0) {
     minDistance = arma::sum(bestDistances) + bestChange;
-    (*medoidIndices)(medoid_to_swap) = best;
+    (*medoidIndices)(medoidToSwap) = best;
   } else {
     minDistance = arma::sum(bestDistances);
   }

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -59,7 +59,7 @@ void FastPAM1::buildFastPAM1(
       total = 0;
       for (size_t j = 0; j < data.n_cols; j++) {
         // computes distance between base and all other points
-        cost = (this->*lossFn)(data, i, j);
+        cost = KMedoids::cachedLoss(data, i, j);
         // compares this with the cached best distance
         if (bestDistances(j) < cost) {
           cost = bestDistances(j);
@@ -75,7 +75,7 @@ void FastPAM1::buildFastPAM1(
 
     // update the medoid assignment and best_distance for this datapoint
     for (size_t l = 0; l < N; l++) {
-      cost = (this->*lossFn)(data, l, (*medoidIndices)(k));
+      cost = KMedoids::cachedLoss(data, l, (*medoidIndices)(k));
       if (cost < bestDistances(l)) {
         bestDistances(l) = cost;
       }
@@ -119,7 +119,7 @@ void FastPAM1::swapFastPAM1(
     deltaTD.fill(-di);
     for (size_t j = 0; j < data.n_cols; j++) {
       if (j != i) {
-        dij = (this->*lossFn)(data, i, j);
+        dij = KMedoids::cachedLoss(data, i, j);
         // update loss change for the current
         if (dij < secondBestDistances(j)) {
           deltaTD.at((*assignments)(j)) += (dij - bestDistances(j));

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -24,11 +24,17 @@ void FastPAM1::fitFastPAM1(const arma::fmat& inputData) {
   steps = 0;
   medoidIndicesBuild = medoidIndices;
   arma::urowvec assignments(data.n_cols);
-
-  auto previous{medoidIndices};
-  FastPAM1::swapFastPAM1(data, &medoidIndices, &assignments);  
+  size_t iter = 0;
+  bool medoidChange = true;
+  while (iter < maxIter && medoidChange) {
+    auto previous{medoidIndices};
+    FastPAM1::swapFastPAM1(data, &medoidIndices, &assignments);
+    medoidChange = arma::any(medoidIndices != previous);
+    iter++;
+  }
   medoidIndicesFinal = medoidIndices;
   labels = assignments;
+  steps = iter;
 }
 
 void FastPAM1::buildFastPAM1(
@@ -91,6 +97,7 @@ void FastPAM1::swapFastPAM1(
   size_t swapIn = 0;
   size_t medoidToSwap = 0;
   size_t N = data.n_cols;
+  size_t iter = 0;
   bool swapPerformed = true;
   arma::fmat sigma(nMedoids, N, arma::fill::zeros);
   arma::frowvec bestDistances(N);
@@ -109,8 +116,8 @@ void FastPAM1::swapFastPAM1(
   float di = 0;
   float dij = 0;
 
-  while (swapPerformed && steps < maxIter) {
-    steps++;
+  while (swapPerformed && iter < maxIter) {
+    iter++;
     // TODO(@motiwari): pragma omp parallel for?
     for (size_t i = 0; i < data.n_cols; i++) {
       di = bestDistances(i);

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -62,7 +62,7 @@ void FastPAM1::buildFastPAM1(
       // TODO(@motiwari): pragma omp parallel for?
       for (size_t j = 0; j < data.n_cols; j++) {
         // computes distance between base and all other points
-        cost = KMedoids::cachedLoss(data, i, j);
+        cost = (*lossFn)(data, i, j);
         // compares this with the cached best distance
         if (bestDistances(j) < cost) {
           cost = bestDistances(j);
@@ -79,7 +79,7 @@ void FastPAM1::buildFastPAM1(
     // update the medoid assignment and best_distance for this datapoint
     // TODO(@motiwari): pragma omp parallel for?
     for (size_t l = 0; l < N; l++) {
-      cost = KMedoids::cachedLoss(data, l, (*medoidIndices)(k));
+      cost = (*lossFn)(data, l, (*medoidIndices)(k));
       if (cost < bestDistances(l)) {
         bestDistances(l) = cost;
       }
@@ -129,7 +129,7 @@ void FastPAM1::swapFastPAM1(
       // TODO(@motiwari): pragma omp parallel for?
       for (size_t j = 0; j < data.n_cols; j++) {
         if (j != i) {
-          dij = KMedoids::cachedLoss(data, i, j);
+          dij = (*lossFn)(data, i, j);
           if (dij < bestDistances(j)) {
             // Case 1: point i becomes the closest medoid for point j,
             // regardless of which medoid j was previously assigned to. deltaTD

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -46,16 +46,18 @@ void FastPAM1::buildFastPAM1(
   arma::frowvec bestDistances(N);
   bestDistances.fill(std::numeric_limits<float>::infinity());
   arma::frowvec sigma(N);
+  float total = 0;
+  float minDistance = std::numeric_limits<float>::infinity();
+  int best = 0;
+  float cost = 0;
+  // TODO (@motiwari): pragma omp parallel for?
   for (size_t k = 0; k < nMedoids; k++) {
-    float minDistance = std::numeric_limits<float>::infinity();
-    int best = 0;
-    // fixes a base datapoint
+    minDistance = std::numeric_limits<float>::infinity();
+    best = 0;
     for (size_t i = 0; i < data.n_cols; i++) {
-      float total = 0;
+      total = 0;
       for (size_t j = 0; j < data.n_cols; j++) {
-        // computes distance between base and all other points
-        float cost = (this->*lossFn)(data, i, j);
-        // compares this with the cached best distance
+        cost = (this->*lossFn)(data, i, j);
         if (bestDistances(j) < cost) {
           cost = bestDistances(j);
         }
@@ -69,8 +71,10 @@ void FastPAM1::buildFastPAM1(
     (*medoidIndices)(k) = best;
 
     // update the medoid assignment and best_distance for this datapoint
+    float cost = 0;
+    #pragma omp parallel for
     for (size_t l = 0; l < N; l++) {
-      float cost = (this->*lossFn)(data, l, (*medoidIndices)(k));
+      cost = (this->*lossFn)(data, l, (*medoidIndices)(k));
       if (cost < bestDistances(l)) {
         bestDistances(l) = cost;
       }
@@ -86,12 +90,15 @@ void FastPAM1::swapFastPAM1(
   float bestChange = 0;
   float minDistance = std::numeric_limits<float>::infinity();
   size_t best = 0;
-  size_t medoid_to_swap = 0;
+  size_t medoidToSwap = 0;
   size_t N = data.n_cols;
   arma::fmat sigma(nMedoids, N, arma::fill::zeros);
   arma::frowvec bestDistances(N);
   arma::frowvec secondBestDistances(N);
-  arma::frowvec delta_td(nMedoids, arma::fill::zeros);
+  arma::frowvec deltaTD(nMedoids, arma::fill::zeros);
+  bool swapPerformed = true;
+  float di = 0;
+  float dij = 0;
 
   // calculate quantities needed for swap, bestDistances and sigma
   KMedoids::calcBestDistancesSwap(
@@ -99,47 +106,57 @@ void FastPAM1::swapFastPAM1(
     medoidIndices,
     &bestDistances,
     &secondBestDistances,
-    assignments);
+    assignments,
+    swapPerformed);
 
-  for (size_t i = 0; i < data.n_cols; i++) {
-    float di = bestDistances(i);
-    // compute loss change for making i a medoid
-    delta_td.fill(-di);
-    for (size_t j = 0; j < data.n_cols; j++) {
-      if (j != i) {
-        float dij = (this->*lossFn)(data, i, j);
+  while (swapPerformed && iter < maxIter) {
+    iter++;
+    for (size_t i = 0; i < data.n_cols; i++) {
+      di = bestDistances(i);
+      // compute loss change for making i a medoid
+      deltaTD.fill(-di);
+      for (size_t j = 0; j < data.n_cols; j++) {
+        dij = (this->*lossFn)(data, i, j);
         // update loss change for the current
         if (dij < secondBestDistances(j)) {
-          delta_td.at((*assignments)(j)) += (dij - bestDistances(j));
+          deltaTD.at((*assignments)(j)) += (dij - bestDistances(j));
         } else {
-          delta_td.at((*assignments)(j)) +=
+          deltaTD.at((*assignments)(j)) +=
             (secondBestDistances(j) - bestDistances(j));
         }
         // reassignment check
         if (dij < bestDistances(j)) {
           // update loss change for others
-          delta_td += (dij -  bestDistances(j));
+          deltaTD += (dij -  bestDistances(j));
           // remove the update for the current
-          delta_td.at((*assignments)(j)) -= (dij -  bestDistances(j));
+          deltaTD.at((*assignments)(j)) -= (dij -  bestDistances(j));
         }
       }
+      
+      // choose the best medoid-to-swap
+      arma::uword newMedoid = deltaTD.index_min();
+      // if the loss change is better than the best loss change,
+      // update the best index identified so far
+      if (deltaTD.min() < bestChange) {
+        bestChange = deltaTD.min();
+        best = i;
+        medoidToSwap = newMedoid;
+      }
     }
-    // choose the best medoid-to-swap
-    arma::uword min_medoid = delta_td.index_min();
-    // if the loss change is better than the best loss change,
-    // update the best index identified so far
-    if (delta_td.min() < bestChange) {
-      bestChange = delta_td.min();
-      best = i;
-      medoid_to_swap = min_medoid;
+    // update the loss and medoid if the loss is improved
+    if (bestChange < -precision) {
+      (*medoidIndices)(medoidToSwap) = best;
+    } else {
+      swapPerformed = false;
     }
-  }
-  // update the loss and medoid if the loss is improved
-  if (bestChange < 0) {
-    minDistance = arma::sum(bestDistances) + bestChange;
-    (*medoidIndices)(medoid_to_swap) = best;
-  } else {
-    minDistance = arma::sum(bestDistances);
+
+    calcBestDistancesSwap(
+      data,
+      medoidIndices,
+      &bestDistances,
+      &secondBestDistances,
+      assignments,
+      swapPerformed);
   }
 }
 }  // namespace km

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -167,6 +167,13 @@ void FastPAM1::swapFastPAM1(
     if (bestChange < 0) {
       minDistance = arma::sum(bestDistances) + bestChange;
       (*medoidIndices)(medoidToSwap) = swapIn;
+      calcBestDistancesSwap(
+        data,
+        medoidIndices,
+        &bestDistances,
+        &secondBestDistances,
+        assignments,
+        swapPerformed);
     } else {
       minDistance = arma::sum(bestDistances);
       swapPerformed = false;

--- a/src/algorithms/fastpam1.cpp
+++ b/src/algorithms/fastpam1.cpp
@@ -50,13 +50,15 @@ void FastPAM1::buildFastPAM1(
   int best = 0;
   float total = 0;
   float cost = 0;
-  // TODO (@motiwari): pragma omp parallel for?
+  // TODO(@motiwari): pragma omp parallel for?
   for (size_t k = 0; k < nMedoids; k++) {
     minDistance = std::numeric_limits<float>::infinity();
     best = 0;
     // fixes a base datapoint
+    // TODO(@motiwari): pragma omp parallel for?
     for (size_t i = 0; i < data.n_cols; i++) {
       total = 0;
+      // TODO(@motiwari): pragma omp parallel for?
       for (size_t j = 0; j < data.n_cols; j++) {
         // computes distance between base and all other points
         cost = KMedoids::cachedLoss(data, i, j);
@@ -74,6 +76,7 @@ void FastPAM1::buildFastPAM1(
     (*medoidIndices)(k) = best;
 
     // update the medoid assignment and best_distance for this datapoint
+    // TODO(@motiwari): pragma omp parallel for?
     for (size_t l = 0; l < N; l++) {
       cost = KMedoids::cachedLoss(data, l, (*medoidIndices)(k));
       if (cost < bestDistances(l)) {
@@ -82,10 +85,6 @@ void FastPAM1::buildFastPAM1(
     }
   }
 }
-
-// TODO: Used cachedLoss everywhere
-// TODO: Add comment about pragma omp parallel for
-// 
 
 void FastPAM1::swapFastPAM1(
   const arma::fmat& data,
@@ -113,10 +112,12 @@ void FastPAM1::swapFastPAM1(
   float di = 0;
   float dij = 0;
 
+  // TODO(@motiwari): pragma omp parallel for?
   for (size_t i = 0; i < data.n_cols; i++) {
     di = bestDistances(i);
     // compute loss change for making i a medoid
     deltaTD.fill(-di);
+    // TODO(@motiwari): pragma omp parallel for?
     for (size_t j = 0; j < data.n_cols; j++) {
       if (j != i) {
         dij = KMedoids::cachedLoss(data, i, j);

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -116,7 +116,12 @@ void KMedoids::setSwapConfidence(size_t newSwapConfidence) {
 }
 
 void KMedoids::setLossFn(std::string loss) {
+  // TODO (@motiwari): Need to fix this
+  // TODO (@motiwari): Add euclidean
+  // TODO (@motiwari): Lower-case input loss
+  // TODO (@motiwari): Add "getLossFn"
   if (std::regex_match(loss, std::regex("L\\d*"))) {
+    // TODO (@motiwari): Need to fix this
     loss = loss.substr(1);
   }
   try {
@@ -130,7 +135,7 @@ void KMedoids::setLossFn(std::string loss) {
       lossFn = &KMedoids::LP;
       lp     = atoi(loss.c_str());
     } else {
-      throw std::invalid_argument("error: unrecognized loss function");
+      throw std::invalid_argument("Error: unrecognized loss function");
     }
   } catch (std::invalid_argument& e) {
     std::cout << e.what() << std::endl;
@@ -142,7 +147,8 @@ void KMedoids::calcBestDistancesSwap(
   const arma::urowvec* medoidIndices,
   arma::frowvec* bestDistances,
   arma::frowvec* secondBestDistances,
-  arma::urowvec* assignments) {
+  arma::urowvec* assignments,
+  const bool swapPerformed) {
   #pragma omp parallel for
   for (size_t i = 0; i < data.n_cols; i++) {
     float best = std::numeric_limits<float>::infinity();
@@ -159,6 +165,11 @@ void KMedoids::calcBestDistancesSwap(
     }
     (*bestDistances)(i) = best;
     (*secondBestDistances)(i) = second;
+  }
+
+  if (!swapPerformed) {
+    // We have converged; update the final loss
+    averageLoss = arma::sum(bestDistances) / data.n_cols;
   }
 }
 

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -168,8 +168,7 @@ std::string KMedoids::getLossFn() const {
   } else if (lossFn == &KMedoids::LINF) {
     return "L-infinity";
   } else if (lossFn == &KMedoids::LP) {
-    std::string lossName = "L" + std::to_string(lp);
-    return lossName;
+    return "L" + std::to_string(lp);
   } else {
     throw std::invalid_argument("Error: Loss Function Undefined!");
   }

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -38,14 +38,18 @@ void KMedoids::fit(const arma::fmat& inputData, const std::string& loss) {
   if (inputData.n_rows == 0) {
     throw std::invalid_argument("Dataset is empty");
   }
-
-  KMedoids::setLossFn(loss);
-  if (algorithm == "PAM") {
-    static_cast<PAM*>(this)->fitPAM(inputData);
-  } else if (algorithm == "BanditPAM") {
-    static_cast<BanditPAM*>(this)->fitBanditPAM(inputData);
-  } else if (algorithm == "FastPAM1") {
-    static_cast<FastPAM1*>(this)->fitFastPAM1(inputData);
+  try {
+    KMedoids::setLossFn(loss);
+    if (algorithm == "PAM") {
+      static_cast<PAM*>(this)->fitPAM(inputData);
+    } else if (algorithm == "BanditPAM") {
+      static_cast<BanditPAM*>(this)->fitBanditPAM(inputData);
+    } else if (algorithm == "FastPAM1") {
+      static_cast<FastPAM1*>(this)->fitFastPAM1(inputData);
+    }
+  } catch (std::invalid_argument& e) {
+    std::cout << e.what() << std::endl;
+    std::cout << "Error: Clustering did not run." << std::endl;
   }
 }
 
@@ -116,28 +120,26 @@ void KMedoids::setSwapConfidence(size_t newSwapConfidence) {
 }
 
 void KMedoids::setLossFn(std::string loss) {
+  // TODO(@motiwari): On setting this, clear the cache and the average loss,
+  // assignments, medoids, etc.
   std::for_each(loss.begin(), loss.end(), [](char& c){
     c = ::tolower(c);
   });
-  try {
-    // TODO(@motiwari): Change this to a switch
-    if (std::regex_match(loss, std::regex("l\\d*"))) {
-      lossFn = &KMedoids::LP;
-      lp = stoi(loss.substr(1));
-    } else if (loss == "manhattan") {
-      lossFn = &KMedoids::manhattan;
-    } else if (loss == "cos" || loss == "cosine") {
-      lossFn = &KMedoids::cos;
-    } else if (loss == "inf") {
-      lossFn = &KMedoids::LINF;
-    } else if (loss == "euclidean") {
-      lossFn = &KMedoids::LP;
-      lp = 2;
-    } else {
-      throw std::invalid_argument("Error: unrecognized loss function");
-    }
-  } catch (std::invalid_argument& e) {
-    std::cout << e.what() << std::endl;
+  // TODO(@motiwari): Change this to a switch
+  if (std::regex_match(loss, std::regex("l\\d*"))) {
+    lossFn = &KMedoids::LP;
+    lp = stoi(loss.substr(1));
+  } else if (loss == "manhattan") {
+    lossFn = &KMedoids::manhattan;
+  } else if (loss == "cos" || loss == "cosine") {
+    lossFn = &KMedoids::cos;
+  } else if (loss == "inf") {
+    lossFn = &KMedoids::LINF;
+  } else if (loss == "euclidean") {
+    lossFn = &KMedoids::LP;
+    lp = 2;
+  } else {
+    throw std::invalid_argument("Error: unrecognized loss function");
   }
 }
 

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -21,13 +21,19 @@ KMedoids::KMedoids(
   const std::string& algorithm,
   size_t maxIter,
   size_t buildConfidence,
-  size_t swapConfidence):
+  size_t swapConfidence,
+  size_t seed):
     nMedoids(nMedoids),
     algorithm(algorithm),
     maxIter(maxIter),
     buildConfidence(buildConfidence),
-    swapConfidence(swapConfidence) {
+    swapConfidence(swapConfidence),
+    seed(seed) {
   KMedoids::checkAlgorithm(algorithm);
+
+  // Though we initialize seed from the given parameter,
+  // we need to call setSeed to pass it to arma
+  KMedoids::setSeed(seed);
 }
 
 KMedoids::~KMedoids() {}
@@ -120,6 +126,15 @@ void KMedoids::setSwapConfidence(size_t newSwapConfidence) {
   swapConfidence = newSwapConfidence;
 }
 
+void KMedoids::setSeed(size_t newSeed) const {
+  seed = newSeed;
+  arma_rng::set_seed(value);
+}
+
+size_t KMedoids::getSeed() const {
+  return seed;
+}
+
 void KMedoids::setLossFn(std::string loss) {
   // TODO(@motiwari): On setting this, clear the cache and the average loss,
   // assignments, medoids, etc.
@@ -153,7 +168,7 @@ std::string KMedoids::getLossFn() const {
   } else if (lossFn == &KMedoids::LINF) {
     return "L-infinity";
   } else if (lossFn == &KMedoids::LP) {
-    std::string lossName = "L-" + std::to_string(lp);
+    std::string lossName = "L" + std::to_string(lp);
     return lossName;
   } else {
     throw std::invalid_argument("Error: Loss Function Undefined!");

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -50,6 +50,7 @@ void KMedoids::fit(const arma::fmat& inputData, const std::string& loss) {
   } catch (std::invalid_argument& e) {
     std::cout << e.what() << std::endl;
     std::cout << "Error: Clustering did not run." << std::endl;
+    throw e;
   }
 }
 

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -116,12 +116,12 @@ void KMedoids::setSwapConfidence(size_t newSwapConfidence) {
 }
 
 void KMedoids::setLossFn(std::string loss) {
-  // TODO (@motiwari): Need to fix this
-  // TODO (@motiwari): Add euclidean
-  // TODO (@motiwari): Lower-case input loss
-  // TODO (@motiwari): Add "getLossFn"
+  // TODO(@motiwari): Need to fix this
+  // TODO(@motiwari): Add euclidean
+  // TODO(@motiwari): Lower-case input loss
+  // TODO(@motiwari): Add "getLossFn"
   if (std::regex_match(loss, std::regex("L\\d*"))) {
-    // TODO (@motiwari): Need to fix this
+    // TODO(@motiwari): Need to fix this
     loss = loss.substr(1);
   }
   try {

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -169,7 +169,7 @@ void KMedoids::calcBestDistancesSwap(
 
   if (!swapPerformed) {
     // We have converged; update the final loss
-    averageLoss = arma::sum(bestDistances) / data.n_cols;
+    averageLoss = arma::accu(*bestDistances) / data.n_cols;
   }
 }
 

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -116,24 +116,23 @@ void KMedoids::setSwapConfidence(size_t newSwapConfidence) {
 }
 
 void KMedoids::setLossFn(std::string loss) {
-  // TODO(@motiwari): Need to fix this
-  // TODO(@motiwari): Add euclidean
-  // TODO(@motiwari): Lower-case input loss
-  // TODO(@motiwari): Add "getLossFn"
-  if (std::regex_match(loss, std::regex("L\\d*"))) {
-    // TODO(@motiwari): Need to fix this
-    loss = loss.substr(1);
-  }
+  std::for_each(loss.begin(), loss.end(), [](char& c){
+    c = ::tolower(c);
+  });
   try {
-    if (loss == "manhattan") {
+    // TODO(@motiwari): Change this to a switch
+    if (std::regex_match(loss, std::regex("l\\d*"))) {
+      lossFn = &KMedoids::LP;
+      lp = stoi(loss.substr(1));
+    } else if (loss == "manhattan") {
       lossFn = &KMedoids::manhattan;
-    } else if (loss == "cos") {
+    } else if (loss == "cos" || loss == "cosine") {
       lossFn = &KMedoids::cos;
     } else if (loss == "inf") {
       lossFn = &KMedoids::LINF;
-    } else if (std::isdigit(loss.at(0))) {
+    } else if (loss == "euclidean") {
       lossFn = &KMedoids::LP;
-      lp     = atoi(loss.c_str());
+      lp = 2;
     } else {
       throw std::invalid_argument("Error: unrecognized loss function");
     }
@@ -141,6 +140,23 @@ void KMedoids::setLossFn(std::string loss) {
     std::cout << e.what() << std::endl;
   }
 }
+
+std::string KMedoids::getLossFn() const {
+  // TODO(@motiwari): make the strings constants
+  if (lossFn == &KMedoids::manhattan) {
+      return "manhattan";
+  } else if (lossFn == &KMedoids::cos) {
+    return "cosine";
+  } else if (lossFn == &KMedoids::LINF) {
+    return "L-infinity";
+  } else if (lossFn == &KMedoids::LP) {
+    std::string lossName = "L-" + std::to_string(lp);
+    return lossName;
+  } else {
+    throw std::invalid_argument("Error: Loss Function Undefined!");
+  }
+}
+
 
 void KMedoids::calcBestDistancesSwap(
   const arma::fmat& data,
@@ -225,6 +241,10 @@ void KMedoids::checkAlgorithm(const std::string& algorithm) const {
     // TODO(@motiwari): Better error type
     throw "unrecognized algorithm";
   }
+}
+
+float KMedoids::getAverageLoss() const {
+  return averageLoss;
 }
 
 float KMedoids::LP(const arma::fmat& data,

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -2,8 +2,7 @@
  * @file kmedoids_algorithm.cpp
  * @date 2020-06-10
  *
- * This file contains the primary C++ implementation of the BanditPAM code.
- *
+ * Contains the primary C++ implementation of the BanditPAM code.
  */
 
 #include <omp.h>
@@ -179,7 +178,9 @@ float KMedoids::calcLoss(
     }
     total += cost;
   }
-  return total;
+
+  // Returns average distance
+  return total/data.n_cols;
 }
 
 float KMedoids::cachedLoss(

--- a/src/algorithms/kmedoids_algorithm.cpp
+++ b/src/algorithms/kmedoids_algorithm.cpp
@@ -126,9 +126,9 @@ void KMedoids::setSwapConfidence(size_t newSwapConfidence) {
   swapConfidence = newSwapConfidence;
 }
 
-void KMedoids::setSeed(size_t newSeed) const {
+void KMedoids::setSeed(size_t newSeed) {
   seed = newSeed;
-  arma_rng::set_seed(value);
+  arma::arma_rng::set_seed(seed);
 }
 
 size_t KMedoids::getSeed() const {

--- a/src/algorithms/pam.cpp
+++ b/src/algorithms/pam.cpp
@@ -2,8 +2,7 @@
  * @file pam.cpp
  * @date 2021-07-25
  *
- * This file contains a C++ implementation of the PAM algorithm.
- *
+ * Contains a C++ implementation of the PAM algorithm.
  */
 
 #include "pam.hpp"

--- a/src/algorithms/pam.cpp
+++ b/src/algorithms/pam.cpp
@@ -76,7 +76,7 @@ void PAM::swapPAM(
   arma::urowvec* assignments) {
   float minDistance = std::numeric_limits<float>::infinity();
   size_t best = 0;
-  size_t medoid_to_swap = 0;
+  size_t medoidToSwap = 0;
   size_t N = data.n_cols;
   arma::frowvec bestDistances(N);
   arma::frowvec secondBestDistances(N);
@@ -114,10 +114,10 @@ void PAM::swapPAM(
       if (total < minDistance) {
         minDistance = total;
         best = i;
-        medoid_to_swap = k;
+        medoidToSwap = k;
       }
     }
   }
-  (*medoidIndices)(medoid_to_swap) = best;
+  (*medoidIndices)(medoidToSwap) = best;
 }
 }  // namespace km

--- a/src/algorithms/pam.cpp
+++ b/src/algorithms/pam.cpp
@@ -3,6 +3,9 @@
  * @date 2021-07-25
  *
  * Contains a C++ implementation of the PAM algorithm.
+ * The original PAM papers are:
+ * 1) Leonard Kaufman and Peter J. Rousseeuw: Clustering by means of medoids.
+ * 2) Leonard Kaufman and Peter J. Rousseeuw: Partitioning around medoids (program pam).
  */
 
 #include "pam.hpp"
@@ -57,7 +60,6 @@ void PAM::buildPAM(
         best = i;
       }
     }
-    // update the medoid index for that of lowest cost
     (*medoidIndices)(k) = best;
 
     // update the medoid assignment and best_distance for this datapoint

--- a/src/algorithms/pam.cpp
+++ b/src/algorithms/pam.cpp
@@ -48,7 +48,7 @@ void PAM::buildPAM(
     for (size_t i = 0; i < data.n_cols; i++) {
       float total = 0;
       for (size_t j = 0; j < data.n_cols; j++) {
-        float cost = (*lossFn)(data, i, j);
+        float cost = (this->*lossFn)(data, i, j);
         // compares this with the cached best distance
         if (bestDistances(j) < cost) {
           cost = bestDistances(j);
@@ -64,7 +64,7 @@ void PAM::buildPAM(
 
     // update the medoid assignment and best_distance for this datapoint
     for (size_t l = 0; l < N; l++) {
-      float cost = (*lossFn)(data, l, (*medoidIndices)(k));
+      float cost = (this->*lossFn)(data, l, (*medoidIndices)(k));
       if (cost < bestDistances(l)) {
         bestDistances(l) = cost;
       }
@@ -95,7 +95,7 @@ void PAM::swapPAM(
       float total = 0;
       for (size_t j = 0; j < data.n_cols; j++) {
         // compute distance between base point and every other datapoint
-        float cost = (*lossFn)(data, i, j);
+        float cost = (this->*lossFn)(data, i, j);
         // if x_j is NOT assigned to k: compares this with
         //   the cached best distance
         // if x_j is assigned to k: compares this with

--- a/src/algorithms/pam.cpp
+++ b/src/algorithms/pam.cpp
@@ -15,13 +15,13 @@
 
 namespace km {
 void PAM::fitPAM(const arma::fmat& inputData) {
-  data = inputData;
-  data = arma::trans(data);
+  data = arma::trans(inputData);
   arma::urowvec medoidIndices(nMedoids);
   PAM::buildPAM(data, &medoidIndices);
   steps = 0;
   medoidIndicesBuild = medoidIndices;
   arma::urowvec assignments(data.n_cols);
+
   size_t i = 0;
   bool medoidChange = true;
   while (i < maxIter && medoidChange) {
@@ -31,8 +31,8 @@ void PAM::fitPAM(const arma::fmat& inputData) {
     i++;
   }
   medoidIndicesFinal = medoidIndices;
-  this->labels = assignments;
-  this->steps = i;
+  labels = assignments;
+  steps = i;
 }
 
 void PAM::buildPAM(
@@ -48,7 +48,7 @@ void PAM::buildPAM(
     for (size_t i = 0; i < data.n_cols; i++) {
       float total = 0;
       for (size_t j = 0; j < data.n_cols; j++) {
-        float cost = KMedoids::cachedLoss(data, i, j);
+        float cost = (*lossFn)(data, i, j);
         // compares this with the cached best distance
         if (bestDistances(j) < cost) {
           cost = bestDistances(j);
@@ -64,7 +64,7 @@ void PAM::buildPAM(
 
     // update the medoid assignment and best_distance for this datapoint
     for (size_t l = 0; l < N; l++) {
-      float cost = KMedoids::cachedLoss(data, l, (*medoidIndices)(k));
+      float cost = (*lossFn)(data, l, (*medoidIndices)(k));
       if (cost < bestDistances(l)) {
         bestDistances(l) = cost;
       }
@@ -95,7 +95,7 @@ void PAM::swapPAM(
       float total = 0;
       for (size_t j = 0; j < data.n_cols; j++) {
         // compute distance between base point and every other datapoint
-        float cost = KMedoids::cachedLoss(data, i, j);
+        float cost = (*lossFn)(data, i, j);
         // if x_j is NOT assigned to k: compares this with
         //   the cached best distance
         // if x_j is assigned to k: compares this with

--- a/src/python_bindings/build_medoids_python.cpp
+++ b/src/python_bindings/build_medoids_python.cpp
@@ -4,7 +4,6 @@
  *
  * Defines the function getMedoidsBuildPython in KMedoidsWrapper class 
  * which is used in Python bindings.
- * 
  */
 
 #include <pybind11/pybind11.h>

--- a/src/python_bindings/fit_python.cpp
+++ b/src/python_bindings/fit_python.cpp
@@ -4,8 +4,8 @@
  *
  * Defines the function fitPython in KMedoidsWrapper class 
  * which is used in Python bindings.
- * 
  */
+
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <carma>

--- a/src/python_bindings/kmedoids_pywrapper.cpp
+++ b/src/python_bindings/kmedoids_pywrapper.cpp
@@ -40,6 +40,8 @@ PYBIND11_MODULE(banditpam, m) {
     &KMedoidsWrapper::getSwapConfidence, &KMedoidsWrapper::setSwapConfidence);
   cls.def_property("loss_function",
     &KMedoidsWrapper::getLossFn, &KMedoidsWrapper::setLossFn);
+  cls.def_property->("seed",
+    &KMedoidsWrapper::setSeed, &KMedoidsWrapper::getSeed);
   medoids_python(&cls);
   build_medoids_python(&cls);
   labels_python(&cls);

--- a/src/python_bindings/kmedoids_pywrapper.cpp
+++ b/src/python_bindings/kmedoids_pywrapper.cpp
@@ -4,8 +4,8 @@
  *
  * Creates the Python bindings for the C++ code that
  * allows it to be called in Python.
- *
  */
+
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <carma>
@@ -43,6 +43,7 @@ PYBIND11_MODULE(banditpam, m) {
   labels_python(&cls);
   steps_python(&cls);
   fit_python(&cls);
+  loss_python(&cls);
   m.attr("__version__") = VERSION_INFO;
 }
 }  // namespace km

--- a/src/python_bindings/kmedoids_pywrapper.cpp
+++ b/src/python_bindings/kmedoids_pywrapper.cpp
@@ -38,6 +38,8 @@ PYBIND11_MODULE(banditpam, m) {
     &KMedoidsWrapper::getBuildConfidence, &KMedoidsWrapper::setBuildConfidence);
   cls.def_property("swap_confidence",
     &KMedoidsWrapper::getSwapConfidence, &KMedoidsWrapper::setSwapConfidence);
+  cls.def_property("loss_function",
+    &KMedoidsWrapper::getLossFunction, &KMedoidsWrapper::setLossFunction);
   medoids_python(&cls);
   build_medoids_python(&cls);
   labels_python(&cls);

--- a/src/python_bindings/kmedoids_pywrapper.cpp
+++ b/src/python_bindings/kmedoids_pywrapper.cpp
@@ -40,7 +40,7 @@ PYBIND11_MODULE(banditpam, m) {
     &KMedoidsWrapper::getSwapConfidence, &KMedoidsWrapper::setSwapConfidence);
   cls.def_property("loss_function",
     &KMedoidsWrapper::getLossFn, &KMedoidsWrapper::setLossFn);
-  cls.def_property->("seed",
+  cls.def_property("seed",
     &KMedoidsWrapper::setSeed, &KMedoidsWrapper::getSeed);
   medoids_python(&cls);
   build_medoids_python(&cls);

--- a/src/python_bindings/kmedoids_pywrapper.cpp
+++ b/src/python_bindings/kmedoids_pywrapper.cpp
@@ -41,7 +41,7 @@ PYBIND11_MODULE(banditpam, m) {
   cls.def_property("loss_function",
     &KMedoidsWrapper::getLossFn, &KMedoidsWrapper::setLossFn);
   cls.def_property("seed",
-    &KMedoidsWrapper::setSeed, &KMedoidsWrapper::getSeed);
+    &KMedoidsWrapper::getSeed, &KMedoidsWrapper::setSeed);
   medoids_python(&cls);
   build_medoids_python(&cls);
   labels_python(&cls);

--- a/src/python_bindings/kmedoids_pywrapper.cpp
+++ b/src/python_bindings/kmedoids_pywrapper.cpp
@@ -39,7 +39,7 @@ PYBIND11_MODULE(banditpam, m) {
   cls.def_property("swap_confidence",
     &KMedoidsWrapper::getSwapConfidence, &KMedoidsWrapper::setSwapConfidence);
   cls.def_property("loss_function",
-    &KMedoidsWrapper::getLossFunction, &KMedoidsWrapper::setLossFunction);
+    &KMedoidsWrapper::getLossFn, &KMedoidsWrapper::setLossFn);
   medoids_python(&cls);
   build_medoids_python(&cls);
   labels_python(&cls);

--- a/src/python_bindings/labels_python.cpp
+++ b/src/python_bindings/labels_python.cpp
@@ -4,7 +4,6 @@
  *
  * Defines the function getLabelsPython in KMedoidsWrapper class 
  * which is used in Python bindings.
- * 
  */
 
 #include <pybind11/pybind11.h>

--- a/src/python_bindings/loss_python.cpp
+++ b/src/python_bindings/loss_python.cpp
@@ -15,11 +15,10 @@
 
 namespace km {
 float km::KMedoidsWrapper::getLossPython() {
-  return KMedoids::calcLoss();
+  return -1.0; // TODO(@motiwari): fix this with averageLoss getter
 }
 
 void loss_python(pybind11::class_<KMedoidsWrapper> *cls) {
   cls->def_property_readonly("average_loss", &KMedoidsWrapper::getLossPython);
-  // cls->def_property_readonly("average_cost", &KMedoidsWrapper::getLossPython);
 }
 }  // namespace km

--- a/src/python_bindings/loss_python.cpp
+++ b/src/python_bindings/loss_python.cpp
@@ -15,7 +15,7 @@
 
 namespace km {
 float km::KMedoidsWrapper::getLossPython() {
-  return -1.0;  // TODO(@motiwari): fix this with averageLoss getter
+  return KMedoids::getAverageLoss();
 }
 
 void loss_python(pybind11::class_<KMedoidsWrapper> *cls) {

--- a/src/python_bindings/loss_python.cpp
+++ b/src/python_bindings/loss_python.cpp
@@ -15,7 +15,7 @@
 
 namespace km {
 float km::KMedoidsWrapper::getLossPython() {
-  return -1.0; // TODO(@motiwari): fix this with averageLoss getter
+  return -1.0;  // TODO(@motiwari): fix this with averageLoss getter
 }
 
 void loss_python(pybind11::class_<KMedoidsWrapper> *cls) {

--- a/src/python_bindings/loss_python.cpp
+++ b/src/python_bindings/loss_python.cpp
@@ -1,0 +1,25 @@
+/**
+ * @file loss_python.cpp
+ * @date 2021-08-16
+ *
+ * Defines the function getLossPython in KMedoidsWrapper class 
+ * which is used in Python bindings.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <carma>
+#include <armadillo>
+
+#include "kmedoids_pywrapper.hpp"
+
+namespace km {
+float km::KMedoidsWrapper::getLossPython() {
+  return KMedoids::calcLoss();
+}
+
+void loss_python(pybind11::class_<KMedoidsWrapper> *cls) {
+  cls->def_property_readonly("average_loss", &KMedoidsWrapper::getLossPython);
+  // cls->def_property_readonly("average_cost", &KMedoidsWrapper::getLossPython);
+}
+}  // namespace km

--- a/src/python_bindings/medoids_python.cpp
+++ b/src/python_bindings/medoids_python.cpp
@@ -4,7 +4,6 @@
  *
  * Defines the function getMedoidsFinalPython in KMedoidsWrapper class 
  * which is used in Python bindings.
- * 
  */
 
 #include <pybind11/pybind11.h>

--- a/src/python_bindings/steps_python.cpp
+++ b/src/python_bindings/steps_python.cpp
@@ -4,7 +4,6 @@
  *
  * Defines the function getStepsPython in KMedoidsWrapper class 
  * which is used in Python bindings.
- * 
  */
 
 #include <pybind11/pybind11.h>

--- a/tests/test_smaller.py
+++ b/tests/test_smaller.py
@@ -12,6 +12,7 @@ from constants import (
     PROPORTION_PASSING,
 )
 
+
 # TODO(@motiwari): Set seeds
 class SmallerTests(unittest.TestCase):
     small_mnist = pd.read_csv("data/MNIST_100.csv", header=None).to_numpy()

--- a/tests/test_smaller.py
+++ b/tests/test_smaller.py
@@ -12,7 +12,7 @@ from constants import (
     PROPORTION_PASSING,
 )
 
-
+# TODO(@motiwari): Set seeds
 class SmallerTests(unittest.TestCase):
     small_mnist = pd.read_csv("data/MNIST_100.csv", header=None).to_numpy()
     mnist_70k = pd.read_csv("data/MNIST_70k.csv", sep=" ", header=None)

--- a/tests/test_smaller.py
+++ b/tests/test_smaller.py
@@ -26,12 +26,25 @@ class SmallerTests(unittest.TestCase):
         """
         for i in range(NUM_SMALL_CASES):
             data = self.mnist_70k.sample(n=SMALL_SAMPLE_SIZE).to_numpy()
+
+            # Test agreement with FastPAM1
             _ = bpam_agrees_pam(
                 k=SMALL_K_SCHEDULE[i % N_SMALL_K],
                 data=data,
                 loss="L2",
                 test_build=True,
                 assert_immediately=True,
+                use_fp=True,
+            )
+
+            # Test agreement with PAM
+            _ = bpam_agrees_pam(
+                k=SMALL_K_SCHEDULE[i % N_SMALL_K],
+                data=data,
+                loss="L2",
+                test_build=True,
+                assert_immediately=True,
+                use_fp=False,
             )
 
     def test_small_scrna(self):
@@ -42,15 +55,28 @@ class SmallerTests(unittest.TestCase):
         count = 0
         for i in range(NUM_SMALL_CASES):
             data = self.scrna.sample(n=SMALL_SAMPLE_SIZE).to_numpy()
+
+            # Test agreement with FastPAM1
             count += bpam_agrees_pam(
                 k=SMALL_K_SCHEDULE[i % N_SMALL_K],
                 data=data,
                 loss="L1",
                 test_build=True,
                 assert_immediately=False,
+                use_fp=True,
+                )
+
+            # Test agreement with PAM
+            count += bpam_agrees_pam(
+                k=SMALL_K_SCHEDULE[i % N_SMALL_K],
+                data=data,
+                loss="L1",
+                test_build=True,
+                assert_immediately=False,
+                use_fp=False,
                 )
         # Occasionally some may fail due to degeneracy in the scRNA dataset
-        self.assertTrue(count >= PROPORTION_PASSING*NUM_SMALL_CASES)
+        self.assertTrue(count >= 2*PROPORTION_PASSING*NUM_SMALL_CASES)
 
     def test_small_mnist_known_cases(self):
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@ from banditpam import KMedoids
 import numpy as np
 
 
-# TODO(@motiwari): change pam to pam everywhere
+# TODO(@motiwari): change pam to alg_name everywhere
 def bpam_agrees_pam(
     k: int,
     data: np.array,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,7 @@
 from banditpam import KMedoids
 import numpy as np
 
-
+# TODO(@motiwari): change pam to fp1 everywhere
 def bpam_agrees_pam(
     k: int,
     data: np.array,
@@ -39,14 +39,14 @@ def bpam_agrees_pam(
 
     if assert_immediately:
         error_message = ''.join(map(str, [
-                                        "BanditPAM and PAM disagree!",
+                                        "BanditPAM and FastPAM1 disagree!",
                                         "\nBanditPAM build medoids:",
                                         bpam_build_medoids,
-                                        "\nPAM build medoids:",
+                                        "\FastPAM1 build medoids:",
                                         pam_build_medoids,
                                         "\nBanditPAM final medoids:",
                                         bpam_final_medoids,
-                                        "\nPAM final medoids",
+                                        "\FastPAM1 final medoids",
                                         pam_final_medoids,
                                         ]
                                     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,13 +2,14 @@ from banditpam import KMedoids
 import numpy as np
 
 
-# TODO(@motiwari): change pam to fp1 everywhere
+# TODO(@motiwari): change pam to pam everywhere
 def bpam_agrees_pam(
     k: int,
     data: np.array,
     loss: str,
     test_build: bool = False,
     assert_immediately: bool = False,
+    use_fp: bool = True,
 ):
     """
     Parameters:
@@ -23,16 +24,18 @@ def bpam_agrees_pam(
     Returns:
         bpam_and_pam_agree: 1 if BanditPAM and PAM agree, 0 otherwise
     """
+    alg_name = "FastPAM1" if use_fp else "PAM"
+
     kmed_bpam = KMedoids(n_medoids=k, algorithm="BanditPAM")
-    kmed_fp1 = KMedoids(n_medoids=k, algorithm="FastPAM1")
+    kmed_pam = KMedoids(n_medoids=k, algorithm=alg_name)
     kmed_bpam.fit(data, loss)
-    kmed_fp1.fit(data, loss)
+    kmed_pam.fit(data, loss)
 
     bpam_build_medoids = sorted(kmed_bpam.build_medoids.tolist())
-    pam_build_medoids = sorted(kmed_fp1.build_medoids.tolist())
+    pam_build_medoids = sorted(kmed_pam.build_medoids.tolist())
 
     bpam_final_medoids = sorted(kmed_bpam.medoids.tolist())
-    pam_final_medoids = sorted(kmed_fp1.medoids.tolist())
+    pam_final_medoids = sorted(kmed_pam.medoids.tolist())
 
     bpam_and_pam_agree = 1 if bpam_final_medoids == pam_final_medoids else 0
     if test_build:
@@ -43,11 +46,11 @@ def bpam_agrees_pam(
                                         "BanditPAM and FastPAM1 disagree!",
                                         "\nBanditPAM build medoids:",
                                         bpam_build_medoids,
-                                        "\nFastPAM1 build medoids:",
+                                        "\n{} build medoids:".format(alg_name),
                                         pam_build_medoids,
                                         "\nBanditPAM final medoids:",
                                         bpam_final_medoids,
-                                        "\nFastPAM1 final medoids",
+                                        "\n{} final medoids:".format(alg_name),
                                         pam_final_medoids,
                                         ]
                                     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,7 +43,8 @@ def bpam_agrees_pam(
 
     if assert_immediately:
         error_message = ''.join(map(str, [
-                                        "BanditPAM and FastPAM1 disagree!",
+                                        "BanditPAM and {} disagree!".format(
+                                            alg_name),
                                         "\nBanditPAM build medoids:",
                                         bpam_build_medoids,
                                         "\n{} build medoids:".format(alg_name),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 from banditpam import KMedoids
 import numpy as np
 
+
 # TODO(@motiwari): change pam to fp1 everywhere
 def bpam_agrees_pam(
     k: int,
@@ -42,11 +43,11 @@ def bpam_agrees_pam(
                                         "BanditPAM and FastPAM1 disagree!",
                                         "\nBanditPAM build medoids:",
                                         bpam_build_medoids,
-                                        "\FastPAM1 build medoids:",
+                                        "\nFastPAM1 build medoids:",
                                         pam_build_medoids,
                                         "\nBanditPAM final medoids:",
                                         bpam_final_medoids,
-                                        "\FastPAM1 final medoids",
+                                        "\nFastPAM1 final medoids",
                                         pam_final_medoids,
                                         ]
                                     )


### PR DESCRIPTION
BanditPAM `v3.0.2` contains several bugfixes:

**Organization and Functionality:**
- We now allow the user to set a `seed` for reproducible results (must be called with `banditpam.set_num_threads(1)` for deterministic reproducibility) (Fixes #176)
- We have added the `KMedoids.average_loss` attribute to contain the final average clustering loss after fitting (Fixes #174)
- We throw an `std::invalid_argument` error properly when specifying an invalid loss function (Fixes #173, Fixes #141)


**Tests:**
- We now also test `PAM` in `tests/test_smaller.py`

**Style:**
- We change `PAM` and `FastPAM1` to use `this->*lossFn` instead of `KMedoids::cachedLoss` to avoid resetting the cache for them; they do not benefit much from a cache anyway
- Nits

**Documentation:**
- Created documentation for new functions